### PR TITLE
LPFG-547: Back-end validation for mandatory fields

### DIFF
--- a/src/learning-catalogue/validator/courseValidator.ts
+++ b/src/learning-catalogue/validator/courseValidator.ts
@@ -66,13 +66,10 @@ export class CourseValidator {
 		this._courseFactory = value
 	}
 
-	async check(
-		params: any,
-		group: 'all' | 'title' | 'shortDescription' | 'description' = 'all'
-	) {
+	async check(params: any, groups: string[] = ['all']) {
 		const validationErrors: ValidationError[] = await validate(
 			this._courseFactory.create(params),
-			{groups: [group]}
+			{groups: groups}
 		)
 
 		return this._validationErrorMapper.map(validationErrors)

--- a/test/unit/learning-catalogue/indexTest.ts
+++ b/test/unit/learning-catalogue/indexTest.ts
@@ -47,18 +47,16 @@ describe('Learning Catalogue tests', () => {
 		}
 
 		const get = sinon.stub()
-		get
-			.withArgs(`${config.url}/courses?page=0&size=10`, {
-				auth: {
-					username: config.username,
-					password: config.password,
-				},
+		get.withArgs(`${config.url}/courses?page=0&size=10`, {
+			auth: {
+				username: config.username,
+				password: config.password,
+			},
+		}).returns(
+			new Promise(resolve => {
+				resolve(response)
 			})
-			.returns(
-				new Promise(resolve => {
-					resolve(response)
-				})
-			)
+		)
 
 		http.get = get
 

--- a/test/unit/learning-catalogue/validator/courseValidatorTest.ts
+++ b/test/unit/learning-catalogue/validator/courseValidatorTest.ts
@@ -17,7 +17,7 @@ describe('CourseValidator tests', () => {
 				{
 					title: 'Course Title',
 				},
-				'title'
+				['title']
 			)
 
 			expect(errors.size).to.equal(0)
@@ -28,7 +28,7 @@ describe('CourseValidator tests', () => {
 				{
 					title: undefined,
 				},
-				'title'
+				['title']
 			)
 
 			expect(errors.size).to.equal(1)
@@ -42,7 +42,7 @@ describe('CourseValidator tests', () => {
 				{
 					title: '',
 				},
-				'title'
+				['title']
 			)
 
 			expect(errors.size).to.equal(1)
@@ -56,7 +56,7 @@ describe('CourseValidator tests', () => {
 		it('should fail validation if shortDescription is missing', async () => {
 			const params = {}
 
-			const errors = await validator.check(params, 'shortDescription')
+			const errors = await validator.check(params, ['shortDescription'])
 
 			expect(errors.size).to.equal(2)
 			expect(errors.fields.shortDescription).to.eql([
@@ -70,7 +70,7 @@ describe('CourseValidator tests', () => {
 				shortDescription: 'x'.repeat(161),
 			}
 
-			const errors = await validator.check(params, 'shortDescription')
+			const errors = await validator.check(params, ['shortDescription'])
 
 			expect(errors.size).to.equal(1)
 			expect(errors.fields.shortDescription).to.eql([
@@ -83,7 +83,7 @@ describe('CourseValidator tests', () => {
 				shortDescription: 'x'.repeat(160),
 			}
 
-			const errors = await validator.check(params, 'shortDescription')
+			const errors = await validator.check(params, ['shortDescription'])
 
 			expect(errors.size).to.equal(0)
 		})
@@ -93,7 +93,7 @@ describe('CourseValidator tests', () => {
 				shortDescription: 'Course short description',
 			}
 
-			const errors = await validator.check(params, 'shortDescription')
+			const errors = await validator.check(params, ['shortDescription'])
 
 			expect(errors.size).to.equal(0)
 		})
@@ -103,7 +103,7 @@ describe('CourseValidator tests', () => {
 		it('should fail validation if description is missing', async () => {
 			const params = {}
 
-			const errors = await validator.check(params, 'description')
+			const errors = await validator.check(params, ['description'])
 
 			expect(errors.size).to.equal(2)
 			expect(errors.fields.description).to.eql([
@@ -117,7 +117,7 @@ describe('CourseValidator tests', () => {
 				description: '',
 			}
 
-			const errors = await validator.check(params, 'description')
+			const errors = await validator.check(params, ['description'])
 
 			expect(errors.size).to.equal(1)
 			expect(errors.fields.description).to.eql([
@@ -130,7 +130,7 @@ describe('CourseValidator tests', () => {
 				description: 'x'.repeat(1501),
 			}
 
-			const errors = await validator.check(params, 'description')
+			const errors = await validator.check(params, ['description'])
 
 			expect(errors.size).to.equal(1)
 			expect(errors.fields.description).to.eql([
@@ -143,7 +143,7 @@ describe('CourseValidator tests', () => {
 				description: 'x'.repeat(1500),
 			}
 
-			const errors = await validator.check(params, 'description')
+			const errors = await validator.check(params, ['description'])
 
 			expect(errors.size).to.equal(0)
 		})
@@ -153,7 +153,7 @@ describe('CourseValidator tests', () => {
 				description: 'Course description',
 			}
 
-			const errors = await validator.check(params, 'description')
+			const errors = await validator.check(params, ['description'])
 
 			expect(errors.size).to.equal(0)
 		})
@@ -282,6 +282,168 @@ describe('CourseValidator tests', () => {
 			}
 
 			const errors = await validator.check(params)
+
+			expect(errors.size).to.equal(0)
+		})
+	})
+
+	describe('Validating all course properties specified', () => {
+		it('should fail validation if title is present but is undefined', async () => {
+			const errors = await validator.check(
+				{
+					title: undefined,
+					description: 'Course description',
+					shortDescription: 'Course short description',
+				},
+				['title', 'shortDescription', 'description']
+			)
+
+			expect(errors.size).to.equal(1)
+			expect(errors.fields.title).to.eql([
+				'validation.course.title.empty',
+			])
+		})
+
+		it('should fail validation if title is present but is an empty string', async () => {
+			const errors = await validator.check(
+				{
+					title: '',
+					description: 'Course description',
+					shortDescription: 'Course short description',
+				},
+				['title', 'shortDescription', 'description']
+			)
+
+			expect(errors.size).to.equal(1)
+			expect(errors.fields.title).to.eql([
+				'validation.course.title.empty',
+			])
+		})
+
+		it('should fail validation if title, shortDescription and description are missing', async () => {
+			const params = {}
+
+			const errors = await validator.check(params, [
+				'title',
+				'shortDescription',
+				'description',
+			])
+
+			expect(errors.size).to.equal(5)
+			expect(errors.fields.shortDescription).to.eql([
+				'validation.course.shortDescription.maxLength',
+				'validation.course.shortDescription.empty',
+			])
+			expect(errors.fields.description).to.eql([
+				'validation.course.description.maxLength',
+				'validation.course.description.empty',
+			])
+			expect(errors.fields.title).to.eql([
+				'validation.course.title.empty',
+			])
+		})
+
+		it('should fail validation if shortDescription is greater than 160 characters', async () => {
+			const params = {
+				title: 'Course Title',
+				description: 'Course description',
+				shortDescription: 'x'.repeat(161),
+			}
+
+			const errors = await validator.check(params, [
+				'title',
+				'shortDescription',
+				'description',
+			])
+
+			expect(errors.size).to.equal(1)
+			expect(errors.fields.shortDescription).to.eql([
+				'validation.course.shortDescription.maxLength',
+			])
+		})
+
+		it('should pass validation if shortDescription is 160 characters or less', async () => {
+			const params = {
+				title: 'Course Title',
+				description: 'Course description',
+				shortDescription: 'x'.repeat(160),
+			}
+
+			const errors = await validator.check(params, [
+				'title',
+				'shortDescription',
+				'description',
+			])
+
+			expect(errors.size).to.equal(0)
+		})
+
+		it('should fail validation if description is greater than 1500 characters', async () => {
+			const params = {
+				title: 'Course Title',
+				description: 'x'.repeat(1501),
+				shortDescription: 'Course short description',
+			}
+
+			const errors = await validator.check(params, [
+				'title',
+				'shortDescription',
+				'description',
+			])
+
+			expect(errors.size).to.equal(1)
+			expect(errors.fields.description).to.eql([
+				'validation.course.description.maxLength',
+			])
+		})
+
+		it('should pass validation if description is 1500 characters or less', async () => {
+			const params = {
+				title: 'Course Title',
+				description: 'x'.repeat(1500),
+				shortDescription: 'Course short description',
+			}
+
+			const errors = await validator.check(params, [
+				'title',
+				'shortDescription',
+				'description',
+			])
+
+			expect(errors.size).to.equal(0)
+		})
+
+		it('should fail validation if description is missing', async () => {
+			const params = {
+				title: 'Course Title',
+				shortDescription: 'Course short description',
+				description: '',
+			}
+
+			const errors = await validator.check(params, [
+				'title',
+				'shortDescription',
+				'description',
+			])
+
+			expect(errors.size).to.equal(1)
+			expect(errors.fields.description).to.eql([
+				'validation.course.description.empty',
+			])
+		})
+
+		it('should pass validation if description and shortDescription are present', async () => {
+			const params = {
+				title: 'Course Title',
+				description: 'Course description',
+				shortDescription: 'Course short description',
+			}
+
+			const errors = await validator.check(params, [
+				'title',
+				'shortDescription',
+				'description',
+			])
 
 			expect(errors.size).to.equal(0)
 		})


### PR DESCRIPTION
Fixed bug in CourseValidator.check method. Second argument was a string rather than a list of fields to validate.