### PR TITLE
Lpfg 874 v3 cancel event

### DIFF
--- a/src/controllers/module/event/eventController.ts
+++ b/src/controllers/module/event/eventController.ts
@@ -18,8 +18,10 @@ import {Validate} from '../../formValidator'
 import {FormController} from '../../formController'
 import {Course} from '../../../learning-catalogue/model/course'
 import {Module} from '../../../learning-catalogue/model/module'
+import * as log4js from 'log4js'
 
 export class EventController implements FormController {
+	logger = log4js.getLogger('controllers/homeController')
 	learningCatalogue: LearningCatalogue
 	learnerRecord: LearnerRecord
 	validator: Validator<Booking>
@@ -449,7 +451,9 @@ export class EventController implements FormController {
 
 			try {
 				await this.learnerRecord.cancelEvent(req.params.eventId, event, req.body.cancellationReason)
-			} catch (e) {}
+			} catch (e) {
+				this.logger.info(`The event has no attendees: ${e}`)
+			}
 
 			req.session!.sessionFlash = {
 				eventCancelledMessage: 'event_cancelled_message',

--- a/src/controllers/module/event/eventController.ts
+++ b/src/controllers/module/event/eventController.ts
@@ -447,9 +447,17 @@ export class EventController implements FormController {
 			let event = res.locals.event
 			event.status = Event.Status.CANCELLED
 
-			await this.learnerRecord.cancelEvent(req.params.eventId, event, req.body.cancellationReason)
+			try {
+				await this.learnerRecord.cancelEvent(req.params.eventId, event, req.body.cancellationReason)
+			} catch (e) {}
 
-			res.redirect(`/content-management/courses/${req.params.courseId}/modules/${req.params.moduleId}/events-overview/${req.params.eventId}`)
+			req.session!.sessionFlash = {
+				eventCancelledMessage: 'event_cancelled_message',
+			}
+
+			return req.session!.save(() => {
+				res.redirect(`/content-management/courses/${req.params.courseId}/modules/${req.params.moduleId}/events-overview/${req.params.eventId}`)
+			})
 		}
 	}
 

--- a/src/controllers/module/event/eventController.ts
+++ b/src/controllers/module/event/eventController.ts
@@ -440,7 +440,9 @@ export class EventController implements FormController {
 
 	public cancelEvent() {
 		return async (req: Request, res: Response) => {
-			res.render('page/course/module/events/cancel')
+			const course: Course = await this.learningCatalogue.getCourse(req.params.courseId)
+			const module: Module = await this.learningCatalogue.getModule(req.params.courseId, req.params.moduleId)
+			res.render('page/course/module/events/cancel', {course: course, module: module})
 		}
 	}
 

--- a/src/controllers/module/event/eventController.ts
+++ b/src/controllers/module/event/eventController.ts
@@ -124,7 +124,10 @@ export class EventController implements FormController {
 		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId', asyncHandler(this.getAttendeeDetails()))
 
 		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId/update', asyncHandler(this.updateBooking()))
+
 		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/cancel', asyncHandler(this.cancelEvent()))
+		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/cancel', asyncHandler(this.setCancelEvent()))
+
 		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId/cancel', asyncHandler(this.getCancelBooking()))
 		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId/cancel', asyncHandler(this.cancelBooking()))
 
@@ -436,6 +439,17 @@ export class EventController implements FormController {
 	public cancelEvent() {
 		return async (req: Request, res: Response) => {
 			res.render('page/course/module/events/cancel')
+		}
+	}
+
+	public setCancelEvent() {
+		return async (req: Request, res: Response) => {
+			let event = res.locals.event
+			event.status = Event.Status.CANCELLED
+
+			await this.learnerRecord.cancelEvent(req.params.eventId, event, req.body.cancellationReason)
+
+			res.redirect(`/content-management/courses/${req.params.courseId}/modules/${req.params.moduleId}/events-overview/${req.params.eventId}`)
 		}
 	}
 

--- a/src/learner-record/index.ts
+++ b/src/learner-record/index.ts
@@ -5,6 +5,7 @@ import {Invite} from './model/invite'
 import {InviteFactory} from './model/factory/inviteFactory'
 import {Booking} from './model/booking'
 import {BookingFactory} from './model/factory/bookingFactory'
+import {Event} from '../learning-catalogue/model/event'
 
 export class LearnerRecord {
 	private _restService: OauthRestService
@@ -60,6 +61,17 @@ export class LearnerRecord {
 			} else {
 				throw new Error(`Learner has already been invite to course: ${e}`)
 			}
+		}
+	}
+
+	async cancelEvent(eventId: string, event: Event, cancellationReason: String) {
+		try {
+			return await this._restService.patch(`/event/${eventId}`, {
+				status: event.status,
+				cancellationReason: cancellationReason,
+			})
+		} catch (e) {
+			throw new Error(`An error occured when try to cancel an event: ${e}`)
 		}
 	}
 

--- a/src/learning-catalogue/model/event.ts
+++ b/src/learning-catalogue/model/event.ts
@@ -15,4 +15,13 @@ export class Event {
 		groups: ['all', 'event.all', 'event.location'],
 	})
 	venue: Venue
+
+	status: Event.Status
+}
+
+export namespace Event {
+	export enum Status {
+		ACTIVE = 'Active',
+		CANCELLED = 'Cancelled',
+	}
 }

--- a/src/learning-catalogue/model/factory/eventFactory.ts
+++ b/src/learning-catalogue/model/factory/eventFactory.ts
@@ -22,6 +22,7 @@ export class EventFactory {
 		event.dateRanges.sort((dateRange1, dateRange2) => DateTime.sortDateRanges(dateRange1, dateRange2))
 
 		event.venue = this.venueFactory.create(data.venue)
+		event.status = data.status ? Event.Status[data.status.toUpperCase() as keyof typeof Event.Status] : Event.Status.ACTIVE
 
 		return event
 	}

--- a/src/learning-catalogue/model/venue.ts
+++ b/src/learning-catalogue/model/venue.ts
@@ -14,9 +14,9 @@ export class Venue {
 		message: 'venue.validation.capacity.empty',
 	})
 	@IsPositive({
-                groups: ['all', 'event.all', 'event.location'],
-                message: 'venue.validation.capacity.positive',
-        })
+		groups: ['all', 'event.all', 'event.location'],
+		message: 'venue.validation.capacity.positive',
+	})
 	capacity: number
 
 	@IsNotEmpty({
@@ -24,9 +24,9 @@ export class Venue {
 		message: 'venue.validation.minCapacity.empty',
 	})
 	@IsPositive({
-                groups: ['all', 'event.all', 'event.location'],
-                message: 'venue.validation.minCapacity.positive',
-        })
+		groups: ['all', 'event.all', 'event.location'],
+		message: 'venue.validation.minCapacity.positive',
+	})
 	minCapacity: number
 
 	availability: number

--- a/test/unit/controllers/module/event/eventControllerTest.ts
+++ b/test/unit/controllers/module/event/eventControllerTest.ts
@@ -609,6 +609,40 @@ describe('EventController', function() {
 		expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/courseId/modules/moduleId/events/eventId/attendee/99/cancel`)
 	})
 
+	it('should render cancel event page', async function() {
+		const request: Request = mockReq()
+		const response: Response = mockRes()
+
+		await eventController.cancelEvent()(request, response)
+
+		expect(response.render).to.have.been.calledOnceWith('page/course/module/events/cancel')
+	})
+
+	it('should cancel event and redirect to events overview page', async function() {
+		const event = new Event()
+
+		const request: Request = mockReq()
+		const response: Response = mockRes()
+
+		request.body.cancellationReason = 'reason'
+
+		request.params.eventId = 'eventId'
+		request.params.courseId = 'courseId'
+		request.params.moduleId = 'moduleId'
+
+		response.locals.event = event
+
+		learnerRecord.cancelEvent = sinon.stub()
+		request.session!.save = sinon
+			.stub()
+			.returns(response.redirect(`/content-management/courses/${request.params.courseId}/modules/${request.params.moduleId}/events-overview/${request.params.eventId}`))
+
+		await eventController.setCancelEvent()(request, response)
+
+		expect(learnerRecord.cancelEvent).to.have.been.calledOnceWith('eventId', event, 'reason')
+		expect(response.redirect).to.have.been.calledOnceWith('/content-management/courses/courseId/modules/moduleId/events-overview/eventId')
+	})
+
 	it('should render cancel attendee page', async function() {
 		let dateRange: DateRange = new DateRange()
 		dateRange.date = '2018-01-02'
@@ -771,6 +805,7 @@ describe('EventController', function() {
 						endTime: '12:30',
 					},
 				],
+				status: Event.Status.ACTIVE,
 			})
 			expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/${courseId}/modules/${moduleId}/events/${eventId}/dateRanges`)
 		})

--- a/test/unit/controllers/module/event/eventControllerTest.ts
+++ b/test/unit/controllers/module/event/eventControllerTest.ts
@@ -240,6 +240,7 @@ describe('EventController', function() {
 				id: 'event-id',
 				venue: venue,
 				dateRanges: [],
+				status: Event.Status.ACTIVE,
 			})
 
 			await eventController.setLocation()(req, res)
@@ -746,6 +747,7 @@ describe('EventController', function() {
 					availability: 5,
 				},
 				dateRanges: [],
+				status: Event.Status.ACTIVE,
 			}
 			learningCatalogue.getEvent = sinon.stub().returns(event)
 			learningCatalogue.updateEvent = sinon.stub()

--- a/test/unit/controllers/module/event/eventControllerTest.ts
+++ b/test/unit/controllers/module/event/eventControllerTest.ts
@@ -610,8 +610,14 @@ describe('EventController', function() {
 	})
 
 	it('should render cancel event page', async function() {
+		const course: Course = new Course()
+		const module: Module = new Module()
+
 		const request: Request = mockReq()
 		const response: Response = mockRes()
+
+		learningCatalogue.getCourse = sinon.stub().returns(course)
+		learningCatalogue.getModule = sinon.stub().returns(module)
 
 		await eventController.cancelEvent()(request, response)
 

--- a/test/unit/learning-catalogue/model/factory/moduleFactoryTest.ts
+++ b/test/unit/learning-catalogue/model/factory/moduleFactoryTest.ts
@@ -4,6 +4,7 @@ import {expect} from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 import {ModuleFactory} from '../../../../../src/learning-catalogue/model/factory/moduleFactory'
 import {EventFactory} from '../../../../../src/learning-catalogue/model/factory/eventFactory'
+import {Event} from '../../../../../src/learning-catalogue/model/event'
 
 chai.use(chaiAsPromised)
 
@@ -68,6 +69,7 @@ describe('ModuleFactory tests', () => {
 					availability: 99,
 				},
 				dateRanges: [{date: '2019-01-01', startTime: '09:00:00', endTime: '17:00:00'}],
+				status: Event.Status.ACTIVE,
 			},
 		]
 

--- a/test/unit/learning-catalogue/model/moduleTest.ts
+++ b/test/unit/learning-catalogue/model/moduleTest.ts
@@ -2,7 +2,7 @@ import {beforeEach, describe, it} from 'mocha'
 import {expect} from 'chai'
 import {Module} from '../../../../src/learning-catalogue/model/module'
 
-describe('Course tests', () => {
+describe('Module tests', () => {
 	let module: Module
 
 	beforeEach(() => {

--- a/views/page/course/module/events/cancel.html
+++ b/views/page/course/module/events/cancel.html
@@ -25,36 +25,36 @@
         <p class="govuk-body">This cannot be undone</p>
         <form action="{{'/content-management/courses/' + courseId + '/modules/' + moduleId + '/events/' + event.id + '/cancel'}}" method="post">
             <input type="hidden" value="{{event.id}}" name="id">
-            {{ govukSelect({
-            id: "cancellationReason",
-            name: "cancellationReason",
-            label: {
-            text: "Cancellation reason"
-            },
-            items: [
-            {
-            value: "",
-            text: "Choose a cancellation reason",
-            selected: true
-            },
-            {
-            value: "reason1",
-            text: "Hard coded Reason 1"
-            },
-            {
-            value: "reason2",
-            text: "Hard coded Reason 2"
-            },
-            {
-            value: "reason3",
-            text: "Hard coded Reason 3"
-            }
-            ]
-            }) }}
+                {{ govukSelect({
+                    id: "cancellationReason",
+                    name: "cancellationReason",
+                    label: {
+                        text: "Cancellation reason"
+                    },
+                    items: [
+                    {
+                        value: "",
+                        text: "Choose a cancellation reason",
+                        selected: true
+                    },
+                    {
+                        value: "reason1",
+                        text: "Hard coded Reason 1"
+                    },
+                    {
+                        value: "reason2",
+                        text: "Hard coded Reason 2"
+                    },
+                    {
+                        value: "reason3",
+                        text: "Hard coded Reason 3"
+                    }
+                    ]
+                }) }}
             <div class="button-container">
                 {{ govukButton({
-                text: "Cancel event",
-                classes: "button-red"
+                    text: "Cancel event",
+                    classes: "button-red"
                 }) }}
             </div>
         </form>

--- a/views/page/course/module/events/cancel.html
+++ b/views/page/course/module/events/cancel.html
@@ -38,16 +38,12 @@
                         selected: true
                     },
                     {
-                        value: "reason1",
+                        value: "The event is no longer available",
                         text: "The event is no longer available"
                     },
                     {
-                        value: "reason2",
-                        text: "The event instructor is ill"
-                    },
-                    {
-                        value: "reason3",
-                        text: "The location has changed"
+                        value: "A placeholder reason",
+                        text: "A placeholder reason"
                     }
                     ]
                 }) }}

--- a/views/page/course/module/events/cancel.html
+++ b/views/page/course/module/events/cancel.html
@@ -39,15 +39,15 @@
                     },
                     {
                         value: "reason1",
-                        text: "Hard coded Reason 1"
+                        text: "The event is no longer available"
                     },
                     {
                         value: "reason2",
-                        text: "Hard coded Reason 2"
+                        text: "The event instructor is ill"
                     },
                     {
                         value: "reason3",
-                        text: "Hard coded Reason 3"
+                        text: "The location has changed"
                     }
                     ]
                 }) }}

--- a/views/page/course/module/events/cancel.html
+++ b/views/page/course/module/events/cancel.html
@@ -19,10 +19,10 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h1 class="govuk-heading-l no-margin">Cancel event</h1>
-        <p class="govuk-body">This event is for the <strong>{{module.title | default("Module title", true)}}</strong> module on the <a href="/content-management/courses/{{courseId}}/overview" class="govuk-link">{{course.title}}</a> course</p>
-        <p class="govuk-body no-margin">Cancelling an event will notify attendeed by email and refund any paid POs.
-        <p class="govuk-body">The event will be labelled as cancelled.</p>
-        <p class="govuk-body">This cannot be undone</p>
+        <p class="govuk-body">This event is for the <strong>{{module.title | default("Module title", true)}}</strong> module on <a href="/content-management/courses/{{courseId}}/overview" class="govuk-link">{{course.title}}</a>.</p>
+        <p class="govuk-body no-margin">Cancelling the event notifies the attendees by email. Payment will be refunded.</p>
+        <p class="govuk-body">The event will be labelled as cancelled on the event overview page.</p>
+        <p class="govuk-body">A cancellation cannot be undone.</p>
         <form action="{{'/content-management/courses/' + courseId + '/modules/' + moduleId + '/events/' + event.id + '/cancel'}}" method="post">
             <input type="hidden" value="{{event.id}}" name="id">
                 {{ govukSelect({
@@ -42,8 +42,8 @@
                         text: "The event is no longer available"
                     },
                     {
-                        value: "A placeholder reason",
-                        text: "A placeholder reason"
+                        value: "Short notice unavailability of the venue",
+                        text: "Short notice unavailability of the venue"
                     }
                     ]
                 }) }}

--- a/views/page/course/module/events/cancel.html
+++ b/views/page/course/module/events/cancel.html
@@ -26,8 +26,8 @@
         <form action="{{'/content-management/courses/' + courseId + '/modules/' + moduleId + '/events/' + event.id + '/cancel'}}" method="post">
             <input type="hidden" value="{{event.id}}" name="id">
             {{ govukSelect({
-            id: "sort",
-            name: "sort",
+            id: "cancellationReason",
+            name: "cancellationReason",
             label: {
             text: "Cancellation reason"
             },

--- a/views/page/course/module/events/cancel.html
+++ b/views/page/course/module/events/cancel.html
@@ -1,4 +1,5 @@
-{% from "input/macro.njk" import govukInput %}
+{% from "select/macro.njk" import govukSelect %}
+{% from "button/macro.njk" import govukButton %}
 
 {% extends "../../../../component/Page.njk" %}
 
@@ -6,35 +7,58 @@
 
 {% set banner = true %}
 {% if event %}
-    {% set backButton = "/content-management/courses/" + courseId + "/modules/" + moduleId + "/events-overview/" + event.id %}
+{% set backButton = "/content-management/courses/" + courseId + "/modules/" + moduleId + "/events-overview/" + event.id %}
 {% else %}
-    {% set backButton = "/content-management/courses/" + courseId + "/overview" %}
+{% set backButton = "/content-management/courses/" + courseId + "/overview" %}
 {% endif %}
-
 
 {% block content %}
 
-    {% set errors = sessionFlash.errors %}
-    {{ errorSummary(errors.fields) }}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <h1 class="govuk-heading-l no-margin">Cancel event</h1>
-            <p class="govuk-body">This event is for the <strong>{{module.title | default("Module title", true)}}</strong> module on the <a href="/content-management/courses/{{courseId}}/overview" class="govuk-link">{{course.title}}</a> course</p>
-            <p class="govuk-body no-margin">Cancelling an event will notify attendeed by email and refund any paid POs.
-            <p class="govuk-body">The event will be labelled as cancelled.</p>
-            <p class="govuk-body">This cannot be undone</p>
-            <form action="" method="post">
-                {{ govukInput({
-                    label: {
-                        text: "Two-thirds width",
-                        classes: "govuk-!-width-two-thirds"
-                    },
-                    classes: "govuk-!-width-two-thirds",
-                    id: "cancel",
-                    name: "cancel"
+{% set errors = sessionFlash.errors %}
+{{ errorSummary(errors.fields) }}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-l no-margin">Cancel event</h1>
+        <p class="govuk-body">This event is for the <strong>{{module.title | default("Module title", true)}}</strong> module on the <a href="/content-management/courses/{{courseId}}/overview" class="govuk-link">{{course.title}}</a> course</p>
+        <p class="govuk-body no-margin">Cancelling an event will notify attendeed by email and refund any paid POs.
+        <p class="govuk-body">The event will be labelled as cancelled.</p>
+        <p class="govuk-body">This cannot be undone</p>
+        <form action="{{'/content-management/courses/' + courseId + '/modules/' + moduleId + '/events/' + event.id + '/cancel'}}" method="post">
+            <input type="hidden" value="{{event.id}}" name="id">
+            {{ govukSelect({
+            id: "sort",
+            name: "sort",
+            label: {
+            text: "Cancellation reason"
+            },
+            items: [
+            {
+            value: "",
+            text: "Choose a cancellation reason",
+            selected: true
+            },
+            {
+            value: "reason1",
+            text: "Hard coded Reason 1"
+            },
+            {
+            value: "reason2",
+            text: "Hard coded Reason 2"
+            },
+            {
+            value: "reason3",
+            text: "Hard coded Reason 3"
+            }
+            ]
+            }) }}
+            <div class="button-container">
+                {{ govukButton({
+                text: "Cancel event",
+                classes: "button-red"
                 }) }}
-            </form>
-        </div>
+            </div>
+        </form>
     </div>
+</div>
 
 {% endblock %}

--- a/views/page/course/module/events/events-overview.html
+++ b/views/page/course/module/events/events-overview.html
@@ -13,6 +13,7 @@
 {% block content %}
 
     {% set emailAddressFoundMessage = sessionFlash.emailAddressFoundMessage %}
+    {% set eventCancelledMessage = sessionFlash.eventCancelledMessage %}
     {% set emailAddress = sessionFlash.emailAddress %}
 
     {% if emailAddressFoundMessage %}
@@ -24,6 +25,14 @@
         <div class="panel govuk-panel govuk-panel--confirmation {{panelError}}">
             <div class="govuk-panel__body custom-panel">
                 <p class="govuk-body"><strong>{{ emailAddress }}</strong>{{ i18n[emailAddressFoundMessage] }}</p>
+            </div>
+        </div>
+    {% endif %}
+
+    {% if eventCancelledMessage %}
+        <div class="panel govuk-panel govuk-panel--confirmation">
+            <div class="govuk-panel__body custom-panel">
+                <p class="govuk-body">This event on <strong>{{(event.dateRanges[0].date) | dateWithMonthAsText}}</strong> for <strong>{{course.title}}</strong> has been cancelled</p>
             </div>
         </div>
     {% endif %}

--- a/views/page/course/module/events/events-overview.html
+++ b/views/page/course/module/events/events-overview.html
@@ -161,8 +161,13 @@
                   {
                       link: '/content-management/courses/' + course.id + '/modules/' + module.id + '/events/' + event.id + '/location/',
                       text: 'Edit location and capacity'
-                  }
-                ] %}
+                  },
+                    {
+                        link: '/content-management/courses/' + course.id + '/modules/' + module.id + '/events/' + event.id + '/cancel',
+                        text: 'Cancel this event'
+                    }
+                ]
+                %}
                 {{ menu("Actions", actions) }}
               {% endblock %}
             </div>


### PR DESCRIPTION
**Needs to merged with Lpfg 679 cancel event in learner-record**

An update of LPFG-874-v2 as events are now soft deleted

Added setCancelEvent function to eventController.ts
Added cancelEvent function to learner-record/index.ts
Added eventStatus to event.ts - currently just to pass the value to learner-record
Added set eventStatus to eventFactory.ts
Updated cancel.html with reason selection
Added cancel event link and event cancelled banner to events-overview.html