### PR TITLE
LPFG-1089: Added PO number to attendee overview

### DIFF
--- a/src/learner-record/model/booking.ts
+++ b/src/learner-record/model/booking.ts
@@ -7,6 +7,7 @@ export class Booking {
 	learnerEmail: string
 	event: string
 	paymentDetails: string
+	poNumber: string
 	status: Booking.Status
 
 	@IsNotEmpty({

--- a/src/learner-record/model/factory/bookingFactory.ts
+++ b/src/learner-record/model/factory/bookingFactory.ts
@@ -14,6 +14,7 @@ export class BookingFactory {
 		booking.learnerEmail = data.learnerEmail
 		booking.event = data.event
 		booking.paymentDetails = data.paymentDetails
+		booking.poNumber = data.poNumber
 		booking.status = data.status ? Booking.Status[data.status.toUpperCase() as keyof typeof Booking.Status] : Booking.Status.REQUESTED
 		booking.cancellationReason = data.cancellationReason
 

--- a/views/page/course/module/events/attendee.html
+++ b/views/page/course/module/events/attendee.html
@@ -35,6 +35,9 @@
                                 </form>
                             {% endif %}
                         </li>
+                        {% if booking.poNumber %}
+                            <li class="list-details view"><p class="govuk-body"><strong>PO Number</strong></p><p class="govuk-body">{{ booking.poNumber }}</p></li>
+                        {% endif %}
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
**Should be merged along side LPFG-1089 from learner record**

If a learner manually entered a PO number, it is displayed in the attendee overview page so that a learning provider can check it manually and confirm it.