### PR TITLE
LPFG-1189-cancellation-reason-enums

### DIFF
--- a/src/controllers/module/event/eventController.ts
+++ b/src/controllers/module/event/eventController.ts
@@ -452,7 +452,10 @@ export class EventController implements FormController {
 		return async (req: Request, res: Response) => {
 			const course: Course = await this.learningCatalogue.getCourse(req.params.courseId)
 			const module: Module = await this.learningCatalogue.getModule(req.params.courseId, req.params.moduleId)
-			res.render('page/course/module/events/cancel', {course: course, module: module})
+
+			const cancellationReasons = await this.learnerRecord.getCancellationReasons()
+
+			res.render('page/course/module/events/cancel', {course: course, module: module, cancellationReasons: cancellationReasons})
 		}
 	}
 

--- a/src/learner-record/index.ts
+++ b/src/learner-record/index.ts
@@ -79,6 +79,14 @@ export class LearnerRecord {
 		}
 	}
 
+	async getCancellationReasons() {
+		try {
+			return await this._restService.get(`/event/cancellationReasons`)
+		} catch (e) {
+			throw new Error(`An error occurred when trying to get cancellation reasons: ${e}`)
+		}
+	}
+
 	set restService(value: OauthRestService) {
 		this._restService = value
 	}

--- a/src/learning-catalogue/model/event.ts
+++ b/src/learning-catalogue/model/event.ts
@@ -18,17 +18,12 @@ export class Event {
 
 	status: Event.Status
 
-	cancellationReason: Event.CancellationReason
+	cancellationReason: string
 }
 
 export namespace Event {
 	export enum Status {
 		ACTIVE = 'Active',
 		CANCELLED = 'Cancelled',
-	}
-
-	export enum CancellationReason {
-		UNAVAILABLE = 'cancellation_reason_unavailable',
-		VENUE = 'cancellation_reason_venue',
 	}
 }

--- a/src/learning-catalogue/model/factory/eventFactory.ts
+++ b/src/learning-catalogue/model/factory/eventFactory.ts
@@ -24,9 +24,7 @@ export class EventFactory {
 		event.venue = this.venueFactory.create(data.venue)
 		event.status = data.status ? Event.Status[data.status.toUpperCase() as keyof typeof Event.Status] : Event.Status.ACTIVE
 
-		if (data.cancellationReason) {
-			event.cancellationReason = Event.CancellationReason[data.cancellationReason.toUpperCase() as keyof typeof Event.CancellationReason]
-		}
+		event.cancellationReason = data.cancellationReason
 
 		return event
 	}

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -227,8 +227,6 @@
 	"terms_and_conditions_edit_title": "Edit terms and conditions",
     "email_address_found_message": " has been invited to this event",
     "could_not_invite_learner": " could not be invited due to an unexpected error",
-    "cancellation_reason_unavailable": "the event is no longer available",
-    "cancellation_reason_venue": "of short notice unavailability of the venue",
 	"validation.learningProvider.name.empty": "Name is required",
 	"validation.cancellationPolicy.name.empty": "Name is required",
 	"validation.cancellationPolicy.shortVersion.empty": "Short version is required",

--- a/test/unit/controllers/module/event/eventControllerTest.ts
+++ b/test/unit/controllers/module/event/eventControllerTest.ts
@@ -738,7 +738,6 @@ describe('EventController', function() {
 			}
 
 			// learningCatalogue.getEvent = sinon.stub().returns(event)
-
 			const request = mockReq(requestConfig)
 			const response = mockRes(responseConfig)
 

--- a/test/unit/controllers/module/event/eventControllerTest.ts
+++ b/test/unit/controllers/module/event/eventControllerTest.ts
@@ -242,7 +242,7 @@ describe('EventController', function() {
 				venue: venue,
 				dateRanges: [],
 				status: Event.Status.ACTIVE,
-				cancellationReason: Event.CancellationReason.UNAVAILABLE,
+				cancellationReason: 'The event is no longer available',
 			})
 
 			learnerRecord.createEvent = sinon.stub().returns(Promise.resolve(event))
@@ -288,7 +288,7 @@ describe('EventController', function() {
 				venue: venue,
 				dateRanges: [],
 				status: Event.Status.ACTIVE,
-				cancellationReason: Event.CancellationReason.UNAVAILABLE,
+				cancellationReason: 'The event is no longer available',
 			})
 
 			const error: Error = new Error()
@@ -636,6 +636,8 @@ describe('EventController', function() {
 		learningCatalogue.getCourse = sinon.stub().returns(course)
 		learningCatalogue.getModule = sinon.stub().returns(module)
 
+		learnerRecord.getCancellationReasons = sinon.stub()
+
 		await eventController.cancelEvent()(request, response)
 
 		expect(response.render).to.have.been.calledOnceWith('page/course/module/events/cancel')
@@ -805,7 +807,7 @@ describe('EventController', function() {
 				},
 				dateRanges: [],
 				status: Event.Status.ACTIVE,
-				cancellationReason: Event.CancellationReason.UNAVAILABLE,
+				cancellationReason: 'The event is no longer available',
 			}
 			learningCatalogue.getEvent = sinon.stub().returns(event)
 			learningCatalogue.updateEvent = sinon.stub()
@@ -830,7 +832,7 @@ describe('EventController', function() {
 					},
 				],
 				status: Event.Status.ACTIVE,
-				cancellationReason: Event.CancellationReason.UNAVAILABLE,
+				cancellationReason: 'The event is no longer available',
 			})
 			expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/${courseId}/modules/${moduleId}/events/${eventId}/dateRanges`)
 		})

--- a/test/unit/learner-record/indexTest.ts
+++ b/test/unit/learner-record/indexTest.ts
@@ -143,4 +143,17 @@ describe('Leaner Record Tests', () => {
 		expect(response).to.equal(event)
 		expect(restService.post).to.have.been.calledOnceWith('/event', event)
 	})
+
+	it('should get cancellation reasons', async () => {
+		const cancellationReasons = {
+			UNAVAILABLE: 'event is unavailable',
+		}
+
+		restService.get = sinon.stub().returns(cancellationReasons)
+
+		const response = await learnerRecord.getCancellationReasons()
+
+		expect(response).to.equal(cancellationReasons)
+		expect(restService.get).to.have.been.calledOnceWith(`/event/cancellationReasons`)
+	})
 })

--- a/views/page/course/module/events/cancel.html
+++ b/views/page/course/module/events/cancel.html
@@ -27,8 +27,8 @@
             <input type="hidden" value="{{event.id}}" name="id">
                 <select class="govuk-select" id="cancellationReason" name="cancellationReason">
                     <option value="">Choose a cancellation reasons</option>
-                    {% for cancellationReason in cancellationReasons %}
-                        <option value="{{cancellationReason}}">{{cancellationReason}}</option>
+                    {% for cancellationReason, value in  cancellationReasons %}
+                        <option value="{{cancellationReason}}">{{value}}</option>
                     {% endfor %}
                 </select>
             <div class="button-container">

--- a/views/page/course/module/events/cancel.html
+++ b/views/page/course/module/events/cancel.html
@@ -25,28 +25,12 @@
         <p class="govuk-body">A cancellation cannot be undone.</p>
         <form action="{{'/content-management/courses/' + courseId + '/modules/' + moduleId + '/events/' + event.id + '/cancel'}}" method="post">
             <input type="hidden" value="{{event.id}}" name="id">
-                {{ govukSelect({
-                    id: "cancellationReason",
-                    name: "cancellationReason",
-                    label: {
-                        text: "Cancellation reason"
-                    },
-                    items: [
-                    {
-                        value: "",
-                        text: "Choose a cancellation reason",
-                        selected: true
-                    },
-                    {
-                        value: "The event is no longer available",
-                        text: "The event is no longer available"
-                    },
-                    {
-                        value: "Short notice unavailability of the venue",
-                        text: "Short notice unavailability of the venue"
-                    }
-                    ]
-                }) }}
+                <select class="govuk-select" id="cancellationReason" name="cancellationReason">
+                    <option value="">Choose a cancellation reasons</option>
+                    {% for cancellationReason in cancellationReasons %}
+                        <option value="{{cancellationReason}}">{{cancellationReason}}</option>
+                    {% endfor %}
+                </select>
             <div class="button-container">
                 {{ govukButton({
                     text: "Cancel event",

--- a/views/page/course/module/events/events-overview.html
+++ b/views/page/course/module/events/events-overview.html
@@ -189,7 +189,7 @@
               {% endblock %}
               {% if event.status == "Cancelled" %}
                 {% block cancellationReason %}
-                    {{ cancellationReason("This event has been cancelled because " + i18n[event.cancellationReason]) }}
+                    {{ cancellationReason("This event has been cancelled because " + event.cancellationReason) }}
                 {% endblock %}
               {% else %}
                 {% block menu %}


### PR DESCRIPTION
**Needs to be merged with fix/cancellation-reason-enums from learning catalogue and learner record**

Get event cancellation reasons from the learner record, rather than having them hard coded in the front end and translated in learner record.

Pass cancellation reasons to front end in eventController.ts
Added getCancellatioReasons functions to learner-record/index.ts
Set cancellatioReason to string type in event.ts
Updated cancel.html to loop through cancellationReasons for reason selecter