### PR TITLE
Lpfg 1156 course redirect

### DIFF
--- a/src/controllers/courseController.ts
+++ b/src/controllers/courseController.ts
@@ -149,7 +149,7 @@ export class CourseController implements FormController {
 
 			req.session!.sessionFlash = {courseAddedSuccessMessage: 'course_added_success_message'}
 			req.session!.save(() => {
-				res.redirect(`/content-management/courses/${savedCourse.id}/overview`)
+				res.redirect(`/content-management/courses/${savedCourse.id}/add-module`)
 			})
 		}
 	}

--- a/views/assets/styles/page/_add-module.scss
+++ b/views/assets/styles/page/_add-module.scss
@@ -51,6 +51,35 @@
 	}
 }
 
+.return-to-course {
+	color: $font-color;
+	display: inline-block;
+	position: relative;
+	margin-top: 15px;
+	margin-bottom: 15px;
+	padding-left: 14px;
+	border-bottom: 1px solid $font-color;
+	text-decoration: none;
+}
+
+.return-to-course::before {
+	display: block;
+	width: 0;
+	height: 0;
+	border-style: solid;
+	border-color: transparent;
+	-webkit-clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
+	clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
+	border-width: 5px 6px 5px 0;
+	border-right-color: inherit;
+	content: '';
+	position: absolute;
+	top: -1px;
+	bottom: 1px;
+	left: 0;
+	margin: auto;
+}
+
 @media screen and (min-width: $tablet-small) {
 	.modules {
 		.module-headers,

--- a/views/component/Page.njk
+++ b/views/component/Page.njk
@@ -108,6 +108,5 @@
 {% block bodyEnd %}
   <script src="/govuk-frontend/all.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
-  <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
-
+  <script>document.body.className = ((document.body.className) ? document.body.className + ' ' : 'js-enabled');</script>
 {% endblock %}

--- a/views/page/course/course-details.html
+++ b/views/page/course/course-details.html
@@ -49,8 +49,3 @@
         </div>
     </div>
 {% endblock %}
-
-{% block bodyEnd %}
-    <script src="/govuk-frontend/all.js"></script>
-    <script>window.GOVUKFrontend.initAll()</script>
-{% endblock %}

--- a/views/page/course/module/add-module.html
+++ b/views/page/course/module/add-module.html
@@ -6,7 +6,7 @@
 {% block pageTitle %}{{ i18n['module_add_title'] }} - {{ i18n['proposition_name'] }}{% endblock %}
 
 {% set banner = true %}
-{% set backButton = "/content-management" %}
+{% set backButton = "/content-management/courses/details/"+ course.id %}
 
 {% block content %}
 

--- a/views/page/course/module/add-module.html
+++ b/views/page/course/module/add-module.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 
-    <a href="/Course-management/" class="govuk-link govuk-body">Course overview</a>
+    <a href="/Course-management/courses/{{course.id}}/overview" class="govuk-body return-to-course">Course overview</a>
 
     {% set errors = sessionFlash.errors %}
     {{ errorSummary(errors.fields) }}
@@ -60,7 +60,7 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <div class="added-modules govuk-!-padding-bottom-5 govuk-!-padding-top-5">
-                    <form action="/content-management/courses/{{ course.id }}/add-module" method="post" class="module-form">
+                    <form action="/content-management/courses/{{course.id}}/add-module" method="post" class="module-form">
                         <h3 class="govuk-heading-m">Add a module</h3>
                         <p class="govuk-body">Choose the type of learning you wish to add to the course</p>
                         <fieldset class="govuk-fieldset module-selector">
@@ -110,7 +110,7 @@
                         </fieldset>
                     </form>
                 <div class="button-container">
-                    <a class="govuk-button" href="/content-management/courses/{{course.id}}/preview">Return to course</a>
+                    <a class="govuk-button" href="/content-management/courses/{{course.id}}/preview">Course overview</a>
                 </div>
             </div>
         </div>

--- a/views/page/course/module/add-module.html
+++ b/views/page/course/module/add-module.html
@@ -6,9 +6,10 @@
 {% block pageTitle %}{{ i18n['module_add_title'] }} - {{ i18n['proposition_name'] }}{% endblock %}
 
 {% set banner = true %}
-{% set backButton = "/content-management/courses/details/"+ course.id %}
 
 {% block content %}
+
+    <a href="/Course-management/" class="govuk-link govuk-body">Course overview</a>
 
     {% set errors = sessionFlash.errors %}
     {{ errorSummary(errors.fields) }}


### PR DESCRIPTION
- Changed redirect on course details save, from overview to add module page
- Added styling for custom 'back' button on add module page. This button now takes the user to the course overview page regardless of whether a module is being edited or added
- Removed unnecessary js imports at the bottom of course-details page
- Changed wording from 'Return to course' to 'Course overview' on green button at bottom of page