### PR TITLE
Fix/Edit Old Modules

### DIFF
--- a/src/controllers/module/fileController.ts
+++ b/src/controllers/module/fileController.ts
@@ -89,10 +89,10 @@ export class FileController {
 				const module = response.locals.module
 				let mediaId = module.mediaId
 
-				if (module.type === Module.Type.VIDEO) {
+				if (module.type === Module.Type.VIDEO && module.url) {
 					const items = module.url.split('/')
 					mediaId = items[items.length - 2]
-				} else if (module.type === Module.Type.E_LEARNING) {
+				} else if (module.type === Module.Type.E_LEARNING && module.url) {
 					const items = module.url.split('/')
 					mediaId = items[items.length - 1]
 				}

--- a/src/controllers/module/fileController.ts
+++ b/src/controllers/module/fileController.ts
@@ -97,9 +97,10 @@ export class FileController {
 					mediaId = items[items.length - 1]
 				}
 
-				const media = await this.restService.get(`/${mediaId}`)
-
-				return response.render('page/course/module/module-file', {type: type, media: media, courseCatalogueUrl: config.COURSE_CATALOGUE.url + '/media'})
+				if (mediaId) {
+					const media = await this.restService.get(`/${mediaId}`)
+					return response.render('page/course/module/module-file', {type: type, media: media, courseCatalogueUrl: config.COURSE_CATALOGUE.url + '/media'})
+				}
 			}
 
 			return response.render('page/course/module/module-file', {
@@ -180,7 +181,7 @@ export class FileController {
 
 			data.type = data.file ? fileType.getFileModuleType(data.file) : module.type
 
-			let errors = await this.moduleValidator.check(data, ['title', 'description', 'mediaId'])
+			let errors = await this.moduleValidator.check(data, ['title', 'description'])
 
 			let file
 			if (data.mediaId) {
@@ -204,10 +205,10 @@ export class FileController {
 			module.description = data.description
 			module.optional = data.isOptional || false
 			module.duration = moment.duration({hours: data.hours, minutes: data.minutes}).asSeconds()
-			module.fileSize = file.fileSizeKB
-			module.mediaId = file.id
-			module.url = config.CONTENT_URL + '/' + file.path
-			module.startPage = file.metadata.startPage
+			module.fileSize = file ? file.fileSizeKB : module.fileSize
+			module.mediaId = file ? file.id : module.mediaId
+			module.url = file ? config.CONTENT_URL + '/' + file.path : module.url
+			module.startPage = file ? file.metadata.startPage : module.startPage
 
 			await this.learningCatalogue
 				.updateModule(course.id, module)

--- a/src/controllers/module/fileController.ts
+++ b/src/controllers/module/fileController.ts
@@ -98,8 +98,17 @@ export class FileController {
 				}
 
 				if (mediaId) {
-					const media = await this.restService.get(`/${mediaId}`)
-					return response.render('page/course/module/module-file', {type: type, media: media, courseCatalogueUrl: config.COURSE_CATALOGUE.url + '/media'})
+					return await this.restService
+						.get(`/${mediaId}`)
+						.then(media => {
+							response.render('page/course/module/module-file', {type: type, media: media, courseCatalogueUrl: config.COURSE_CATALOGUE.url + '/media'})
+						})
+						.catch(() => {
+							response.render('page/course/module/module-file', {
+								type: type,
+								courseCatalogueUrl: config.COURSE_CATALOGUE.url + '/media',
+							})
+						})
 				}
 			}
 

--- a/test/unit/controllers/module/fileControllerTest.ts
+++ b/test/unit/controllers/module/fileControllerTest.ts
@@ -185,7 +185,7 @@ describe('File Controller Test', function() {
 
 		await fileController.editFile()(request, response, next)
 
-		expect(moduleValidator.check).to.have.been.calledOnceWith(request.body, ['title', 'description', 'mediaId'])
+		expect(moduleValidator.check).to.have.been.calledOnceWith(request.body, ['title', 'description'])
 		expect(mediaRestService.get).to.have.been.calledOnceWith(`/mediaId`)
 		expect(learningCatalogue.updateModule).to.have.been.calledOnceWith('courseId', module)
 		expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/${course.id}/preview`)
@@ -229,7 +229,7 @@ describe('File Controller Test', function() {
 
 		await fileController.editFile()(request, response, next)
 
-		expect(moduleValidator.check).to.have.been.calledOnceWith(request.body, ['title', 'description', 'mediaId'])
+		expect(moduleValidator.check).to.have.been.calledOnceWith(request.body, ['title', 'description'])
 		expect(mediaRestService.get).to.have.been.calledOnceWith(`/mediaId`)
 		expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/${course.id}/module-file`)
 	})

--- a/test/unit/controllers/module/fileControllerTest.ts
+++ b/test/unit/controllers/module/fileControllerTest.ts
@@ -74,7 +74,7 @@ describe('File Controller Test', function() {
 		const request: Request = mockReq()
 		const response: Response = mockRes()
 
-		mediaRestService.get = sinon.stub().returns({id: 'mediaId'})
+		mediaRestService.get = sinon.stub().returns(Promise.resolve({id: 'mediaId'}))
 
 		request.params.moduleId = 'moduleId'
 		response.locals.module = module

--- a/views/page/course/module/module-file.html
+++ b/views/page/course/module/module-file.html
@@ -178,6 +178,7 @@
                     </div>
                 </fieldset>
 
+                {% if not module.id %}
                 <div class="{{chooseFileButtonClass}}">
                     <fieldset class="govuk-fieldset">
                         <div class="add-file-form govuk-form-group">
@@ -218,6 +219,13 @@
                 type: "input",
                 classes: "button-blue left-aligned"
                 }) }}
+                {% else %}
+                {{ govukWarningText({
+                    text: "If you want to amend the attached file, return to the course modules page and delete this module. Create a new module using the existing title and description and the new attachment.",
+                    iconFallbackText: "Warning"
+                }) }}
+                {% endif %}
+
 
                 {{ govukCheckboxes({
                 idPrefix: "isOptional",
@@ -244,6 +252,7 @@
                     attributes: {id: "submitButton"}
                     }) }}
                 </div>
+
             </form>
             <a class="cancel-button govuk-body govuk-link" href="/content-management/courses/{{course.id}}/preview">Cancel</a>
         </div>


### PR DESCRIPTION
**Needs to be merged with fix/edit-old-modules from learning catalogue**

This addresses the problem of not being able to edit older modules with no media metadata.

If there is no mediaId when loading the edit modules page, don't attempt to load the media metadata and just load the page with no file displayed.

Removed the validation for mediaId on edit module as there is no way to have no mediaId when editing a module, except in the case where an old module is being edited. In the case where there is no media, the module retains its old media values.