### PR TITLE
Creating associate learning

### DIFF
--- a/src/controllers/module/linkModuleController.ts
+++ b/src/controllers/module/linkModuleController.ts
@@ -118,6 +118,7 @@ export class LinkModuleController {
 			module.description = req.body.description
 			module.url = req.body.url
 			module.optional = req.body.optional
+			module.associatedLearning = req.body.associatedLearning
 			module.duration = moment
 				.duration({
 					hours: req.body.hours,

--- a/src/learning-catalogue/model/factory/linkFactory.ts
+++ b/src/learning-catalogue/model/factory/linkFactory.ts
@@ -10,7 +10,7 @@ export class LinkFactory {
 		linkModule.url = data.url
 		linkModule.duration = data.duration
 		linkModule.isOptional = data.isOptional
-
+		linkModule.associatedLearning = data.associatedLearning
 		return linkModule
 	}
 }

--- a/src/learning-catalogue/model/factory/moduleFactory.ts
+++ b/src/learning-catalogue/model/factory/moduleFactory.ts
@@ -26,7 +26,6 @@ export class ModuleFactory {
 		module.duration = data.duration
 		module.cost = !isNaN(Number(data.cost)) ? Number(data.cost) : data.cost
 		module.optional = data.optional
-
 		return module
 	}
 
@@ -53,6 +52,7 @@ export class ModuleFactory {
 			module.duration = data.duration
 			module.id = data.id
 			module.isOptional = data.isOptional
+			module.associatedLearning = data.associatedLearning
 			module.title = data.title
 			module.url = data.url
 			return module

--- a/src/learning-catalogue/model/linkModule.ts
+++ b/src/learning-catalogue/model/linkModule.ts
@@ -39,6 +39,7 @@ export class LinkModule extends Module {
 	duration: number
 
 	isOptional: boolean
+	associatedLearning: boolean
 
 	type: Module.Type.LINK
 }

--- a/views/page/course/module/module-link.html
+++ b/views/page/course/module/module-link.html
@@ -199,6 +199,27 @@
                 ]
             }) }}
 
+            {{ govukCheckboxes({
+                idPrefix: "associatedLearning",
+                name: "associatedLearning",
+                classes: "font-light",
+                fieldset: {
+                    legend: {
+                        text: "Is this an associated learning module?",
+                        isPageHeading: true,
+                        classes: "font-bold"
+                    }
+            },
+            items: [
+                {
+                    value: "true",
+                    text: "Yes, this is associated learning module",
+                    checked: true if module.associatedLearning
+                }
+            ]
+            }) }}
+
+
             {{ govukButton({
                 text: "Edit item" if module.id else "Add item",
                 type: "submit"


### PR DESCRIPTION
This creates associate learning for link modules. So, if the admin creates a course and adds a face-to-face module. And then adds a link module to this course and sets it as associate learning. Then the user should not be able to start the link module unless the admin confirms the booking and the payment of the user.