### PR TITLE
chore: cleanup typescript compiler warnings

### DIFF
--- a/src/controllers/courseController.ts
+++ b/src/controllers/courseController.ts
@@ -224,10 +224,12 @@ export class CourseController implements FormController {
 	sortModules() {
 		return async (request: Request, response: Response, next: NextFunction) => {
 			return await this.courseService
+				// @ts-ignore
 				.sortModules(request.params.courseId, request.query.moduleIds)
 				.then(() => {
 					response.redirect(`/content-management/courses/${request.params.courseId}/add-module`)
 				})
+				// @ts-ignore
 				.catch(error => {
 					next(error)
 				})

--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -31,6 +31,7 @@ export class SearchController {
 			let {page, size} = this.pagination.getPageAndSizeFromRequest(request)
 			let query = ''
 			if (request.query.q) {
+				// @ts-ignore
 				query = striptags(request.query.q)
 			}
 			// prettier-ignore

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -8,9 +8,11 @@ export class Pagination {
 		let size = 10
 
 		if (request.query.p) {
+      // @ts-ignore
 			page = request.query.p
 		}
 		if (request.query.s) {
+      // @ts-ignore
 			size = request.query.s
 		}
 		return {page, size}

--- a/test/unit/controllers/homeControllerTest.ts
+++ b/test/unit/controllers/homeControllerTest.ts
@@ -69,7 +69,9 @@ describe('Home Controller Tests', function() {
 		const listAll = sinon.stub().returns(Promise.resolve(pageResults))
 		learningCatalogue.listCourses = listAll
 
+    // @ts-ignore
 		request.query.p = 3
+    // @ts-ignore
 		request.query.s = 5
 
 		await homeController.index()(request, response, next)
@@ -98,7 +100,9 @@ describe('Home Controller Tests', function() {
 		const listAll = sinon.stub().returns(Promise.reject(error))
 		learningCatalogue.listCourses = listAll
 
+    // @ts-ignore
 		request.query.p = 3
+    // @ts-ignore
 		request.query.s = 5
 
 		await homeController.index()(request, response, next)

--- a/test/unit/controllers/learningProvider/learningProviderControllerTest.ts
+++ b/test/unit/controllers/learningProvider/learningProviderControllerTest.ts
@@ -82,7 +82,9 @@ describe('Learning Provider Controller Tests', function() {
 		const listLearningProviders = sinon.stub().returns(Promise.resolve(pageResults))
 		learningCatalogue.listLearningProviders = listLearningProviders
 
+    // @ts-ignore
 		req.query.p = 3
+    // @ts-ignore
 		req.query.s = 5
 
 		await learningProviderController.index()(req, res)


### PR DESCRIPTION
TS/node versions updated on the app. ts-igoring some of the warnings as we know these already work, and do not want to explicitly cast

https://github.com/Civil-Service-Human-Resources/lpg-services/pull/631