### PR TITLE
LC-14: fixing delete token issue

### DIFF
--- a/src/controllers/agencyTokenController.ts
+++ b/src/controllers/agencyTokenController.ts
@@ -232,14 +232,12 @@ export class AgencyTokenController implements FormController {
 			await this.csrs
 				.deleteAgencyToken(organisationalUnit.id)
 				.then(() => {
-					response.redirect(`/content-management/organisations/${organisationalUnit.id}/overview`)
+					request.session!.sessionFlash = {displayAgencyTokenRemovedMessage: true, organisationalUnit: organisationalUnit}
+					return response.redirect(`/content-management/organisations/${organisationalUnit.id}/overview`)
 				})
 				.catch(error => {
 					next(error)
 				})
-			request.session!.sessionFlash = {displayAgencyTokenRemovedMessage: true, organisationalUnit: organisationalUnit}
-
-			response.redirect(`/content-management/organisations/${organisationalUnit.id}/overview`)
 		}
 	}
 

--- a/test/unit/controllers/agencyTokenControllerTest.ts
+++ b/test/unit/controllers/agencyTokenControllerTest.ts
@@ -66,7 +66,7 @@ describe('AgencyTokenController', () => {
 		})
 	})
 
-	describe.only('#createAgencyToken', () => {
+	describe('#createAgencyToken', () => {
 		it('should create agency token for organisation and redirect to the Organisation Overview page if data submitted is valid', async function() {
 			req.body = {capacity: capacity, tokenNumber: tokenNumber}
 			req.session!.domainsForAgencyToken = domains


### PR DESCRIPTION
Delete token function was doing a res.redirect twice, causing issues with response resulting in an error. Tidied up this function to only return res.redirect once.
Fixed an issue where only one of the unit tests was being called during npm test.