### PR TITLE
hotfix: adding additional conditions for agency capacity validation

### DIFF
--- a/src/lib/agencyTokenService.ts
+++ b/src/lib/agencyTokenService.ts
@@ -13,7 +13,7 @@ export class AgencyTokenService {
 
 	validateCapacity(numberString: string) {
 		const parsedInt = parseInt(numberString)
-		return !isNaN(parsedInt)
+		return !isNaN(parsedInt) && parsedInt >= 0 && parsedInt <= 2147483647
 	}
 
 	validateDomains(domains: any) {

--- a/test/unit/lib/agencyTokenServiceTest.ts
+++ b/test/unit/lib/agencyTokenServiceTest.ts
@@ -37,6 +37,48 @@ describe('Agency Token Service', () => {
 
 			expect(capacityIsValid).to.be.true
 		})
+
+		it('should return `false` when a number is greater than java int max', async () => {
+			const capacity = '2147483648'
+			const capacityIsValid = agencyTokenService.validateCapacity(capacity)
+
+			expect(capacityIsValid).to.be.false
+		})
+
+		it('should return `true` when a number is equal to java int max', async () => {
+			const capacity = '2147483647'
+			const capacityIsValid = agencyTokenService.validateCapacity(capacity)
+
+			expect(capacityIsValid).to.be.true
+		})
+
+		it('should return `true` when a number is one less than java int max', async () => {
+			const capacity = '2147483646'
+			const capacityIsValid = agencyTokenService.validateCapacity(capacity)
+
+			expect(capacityIsValid).to.be.true
+		})
+
+		it('should return `false` when a number is less than 0', async () => {
+			const capacity = '-1'
+			const capacityIsValid = agencyTokenService.validateCapacity(capacity)
+
+			expect(capacityIsValid).to.be.false
+		})
+
+		it('should return `true` when a number is equal to 0', async () => {
+			const capacity = '0'
+			const capacityIsValid = agencyTokenService.validateCapacity(capacity)
+
+			expect(capacityIsValid).to.be.true
+		})
+
+		it('should return `true` when a number is greater than 0', async () => {
+			const capacity = '1'
+			const capacityIsValid = agencyTokenService.validateCapacity(capacity)
+
+			expect(capacityIsValid).to.be.true
+		})
 	})
 
 	describe('#validateDomains', () => {


### PR DESCRIPTION
Adding an additional client-side validation check on the capacity value to be greater than 0 and within the boundaries of java integers (i.e less than or equal to 2147483647). If a value greater than 2147483647 is sent to csrs, a generic spring exception will be thrown (making it more difficult to map to a user-facing error message).

User-defined min and max capacity validation will still be done by the api, but if we send a value outside the boundaries of a java int, we're limited in the ability to catch and provide custom error message, hence why we want this pre-http check.