### PR TITLE
fix: error.html

### DIFF
--- a/views/page/error.html
+++ b/views/page/error.html
@@ -11,8 +11,8 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
-        <p class="govuk-body">Something went horribly wrong. But don't worry, we're looking into it.</p>
-        <p class="govuk-body">Please <a class="govuk-link" href="{{ lpgUiUrl }}/sign-out">log-out</a> and try again.</p>
+        <p class="govuk-body">Something has gone wrong with the system. We're looking into it.</p>
+        <p class="govuk-body">Please <a class="govuk-link" href="{{ lpgUiUrl }}/sign-out">sign out</a> and try again.</p>
         <p class="govuk-body">
             <a class="govuk-link" href="mailto:feedback@cslearning.gov.uk">Contact us</a> for more information.
         </p>


### PR DESCRIPTION
For reference, this is the guidance as per the design system https://design-system.service.gov.uk/patterns/problem-with-the-service-pages/. It suggests you use clear and concise language, so language like "horribly" and "don't worry" is fluff.

This comes up every few months on the xgov slack. Generally people aren't happy with the content here (content designers especially..!). 

**changes made**
- copy is now "Something has gone wrong with the system. We're looking into it"
- also changed "log-out" to "Sign out" so it mirrors the menu 
