### PR TITLE
Link to remove parent organisation

### DIFF
--- a/src/controllers/organisationController.ts
+++ b/src/controllers/organisationController.ts
@@ -55,6 +55,7 @@ export class OrganisationController implements FormController {
 		this.router.post('/content-management/organisations/:organisationalUnitId', asyncHandler(this.updateOrganisation()))
 		this.router.get('/content-management/organisations/:organisationalUnitId/confirm-delete', asyncHandler(this.confirmDelete()))
 		this.router.post('/content-management/organisations/:organisationalUnitId/delete', asyncHandler(this.deleteOrganisation()))
+		this.router.get('/content-management/organisations/:organisationalUnitId/unlink-parent-confirm', asyncHandler(this.confirmParentOrganisationRemoval()))
 	}
 
 	public getOrganisationList() {
@@ -153,6 +154,12 @@ export class OrganisationController implements FormController {
 	public confirmDelete() {
 		return async (request: Request, response: Response) => {
 			response.render('page/organisation/delete-organisation')
+		}
+	}
+
+	public confirmParentOrganisationRemoval(){
+		return async (request: Request, response: Response) => {
+			response.render('page/organisation/remove-parent')
 		}
 	}
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -152,6 +152,7 @@
 			"addANewOrganisation": "Add a new organisation",
 			"editAnOrganisation": "Edit an organisation",
 			"removeAnOrganisation": "Remove an organisation",
+			"removeParentOrganisation": "Remove parent organisation",
 			"organisationOverview": "Organisation overview"
 		},
 		"validation": {

--- a/views/page/organisation/organisation-overview.html
+++ b/views/page/organisation/organisation-overview.html
@@ -84,6 +84,10 @@
                     {
                         link: "/content-management/organisations/" + organisationalUnit.id + "/confirm-delete",
                         text: "Remove organisation"
+                    },
+                    {
+                        link: "/content-management/organisations/" + organisationalUnit.id + "/unlink-parent-confirm",
+                        text: "Unlink parent"
                     }
                 ] %}
                 {{ menu("Actions", actions) }}

--- a/views/page/organisation/remove-parent.html
+++ b/views/page/organisation/remove-parent.html
@@ -1,0 +1,27 @@
+{% from "button/macro.njk" import govukButton %}
+
+{% extends "../../component/Page.njk" %}
+
+{% block pageTitle %}{{ i18n.organisations.title.removeAnOrganisation }} - {{ i18n.proposition_name }}{% endblock %}
+
+{% set banner = true %}
+{% set backButton = "/content-management/organisations/" + organisationalUnit.id + "/overview" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-m govuk-!-font-size-36">{{ i18n.organisations.title.removeParentOrganisation }}</h1>
+        <p class="govuk-body">Are you sure you want to remove the parent organisation of {{ organisationalUnit.name }}{{ " (" + organisationalUnit.abbreviation + ")" if organisationalUnit.abbreviation else "" }}?</p>
+        <p class="govuk-body">This action is irreversible.</p>
+        <form action="/content-management/organisations/{{ organisationalUnit.id }}/delete" method="post">
+            <fieldset class="govuk-fieldset">
+                {{ govukButton({
+                    text: "Remove parent organisation",
+                    classes: "button-red"
+                }) }}
+            </fieldset>
+        </form>
+        <a class="cancel-button govuk-link" href="/content-management/organisations/{{ organisationalUnit.id }}/overview">Cancel</a>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Changes

This pull request:

1. adds a new link in the Organisation Overview page "Unlink parent organisation":

![](https://user-images.githubusercontent.com/97103826/171174931-a91a26d7-d0bf-4035-978b-68268cc29417.png)

2. A page to confirm removal of parent organisation:

![](https://user-images.githubusercontent.com/97103826/171175254-f2b36b1f-49b4-44bf-b97d-a387287f1f37.png)

3. Config file for Azure Pipelines

## Integration test

https://user-images.githubusercontent.com/97103826/171176176-75d75348-414f-4a84-aac7-41c788aa91b9.mov

1. The new link is visible in the Overview page
2. Once clicked, the user is taken to a confirmation page
3. Once the button is clicked, the parent organisation is removed from the organisation
4. The new link disappears (not visible for organisations without a parent organisation)
