### PR TITLE
LC 2202 launch modules

### DIFF
--- a/src/applicationContext.ts
+++ b/src/applicationContext.ts
@@ -83,6 +83,8 @@ import { OrganisationalUnitCache } from './csrs/organisationalUnitCache'
 import { createClient } from 'redis'
 import { AgencyTokenHttpService } from './csrs/agencyTokenHttpService'
 import { OrganisationalUnitTypeaheadCache } from './csrs/organisationalUnitTypeaheadCache'
+import {CslServiceConfig} from './csl-service/cslServiceConfig'
+import {CslServiceClient} from './csl-service/client'
 
 export class ApplicationContext {
 	actionWorkerService: ActionWorkerService
@@ -135,6 +137,8 @@ export class ApplicationContext {
 	dateRangeFactory: DateRangeFactory
 	dateStartEndFactory: DateStartEndFactory
 	dateRangeValidator: Validator<DateRange>
+	cslServiceConfig: CslServiceConfig
+	cslService: CslServiceClient
 	learnerRecord: LearnerRecord
 	learnerRecordConfig: LearnerRecordConfig
 	inviteFactory: InviteFactory
@@ -299,12 +303,15 @@ export class ApplicationContext {
 		this.bookingFactory = new BookingFactory()
 		this.inviteFactory = new InviteFactory()
 
+		this.cslServiceConfig = new CslServiceConfig(config.CSL_SERVICE.url, config.CSL_SERVICE.timeout)
+		this.cslService = new CslServiceClient(new OauthRestService(this.cslServiceConfig, this.auth))
+
 		this.learnerRecordConfig = new LearnerRecordConfig(config.LEARNER_RECORD.url, config.LEARNER_RECORD.timeout)
 		this.learnerRecord = new LearnerRecord(this.learnerRecordConfig, this.auth, this.bookingFactory, this.inviteFactory)
 
 		this.bookingValidator = new Validator<Booking>(this.bookingFactory)
 
-		this.actionWorkerService = new ActionWorkerService(this.learningCatalogue, this.csrsService, this.learnerRecord, this.organisationalUnitService)
+		this.actionWorkerService = new ActionWorkerService(this.learningCatalogue, this.csrsService, this.learnerRecord, this.organisationalUnitService, this.cslService)
 		this.actionWorkerService.init()
 
 		this.eventController = new EventController(

--- a/src/applicationContext.ts
+++ b/src/applicationContext.ts
@@ -198,9 +198,12 @@ export class ApplicationContext {
 
 		this.identityConfig = new IdentityConfig(config.AUTHENTICATION.authenticationServiceUrl, config.AUTHENTICATION.timeout)
 
+		this.cslServiceConfig = new CslServiceConfig(config.CSL_SERVICE.url, config.CSL_SERVICE.timeout)
+		this.cslService = new CslServiceClient(new OauthRestService(this.cslServiceConfig, this.auth))
+
 		this.learningCatalogueConfig = new LearningCatalogueConfig(config.COURSE_CATALOGUE.url, config.COURSE_CATALOGUE.timeout)
 
-		this.learningCatalogue = new LearningCatalogue(this.learningCatalogueConfig, this.auth)
+		this.learningCatalogue = new LearningCatalogue(this.learningCatalogueConfig, this.auth, this.cslService)
 
 		this.courseFactory = new CourseFactory()
 
@@ -302,9 +305,6 @@ export class ApplicationContext {
 
 		this.bookingFactory = new BookingFactory()
 		this.inviteFactory = new InviteFactory()
-
-		this.cslServiceConfig = new CslServiceConfig(config.CSL_SERVICE.url, config.CSL_SERVICE.timeout)
-		this.cslService = new CslServiceClient(new OauthRestService(this.cslServiceConfig, this.auth))
 
 		this.learnerRecordConfig = new LearnerRecordConfig(config.LEARNER_RECORD.url, config.LEARNER_RECORD.timeout)
 		this.learnerRecord = new LearnerRecord(this.learnerRecordConfig, this.auth, this.bookingFactory, this.inviteFactory)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -69,6 +69,11 @@ export const LEARNER_RECORD = set({
 	timeout: Number(env.LEARNER_RECORD_TIMEOUT_MS)
 })
 
+export const CSL_SERVICE = set({
+	url: env.CSL_SERVICE_URL || 'http://localhost:9003',
+	timeout: Number(env.CSL_SERVICE_TIMEOUT_MS)
+})
+
 export const REGISTRY_SERVICE = set({
 	url: env.REGISTRY_SERVICE_URL || 'http://localhost:9002',
 	timeout: Number(env.REGISTRY_SERVICE_TIMEOUT_MS)

--- a/src/csl-service/client.ts
+++ b/src/csl-service/client.ts
@@ -1,0 +1,10 @@
+import {OauthRestService} from 'lib/http/oauthRestService'
+
+export class CslServiceClient {
+
+	constructor(private readonly _http: OauthRestService) { }
+
+	async clearCourseRecordCache(userId: string, courseId: string) {
+		await this._http.get(`/learner/${userId}/course_record/${courseId}`)
+	}
+}

--- a/src/csl-service/client.ts
+++ b/src/csl-service/client.ts
@@ -5,6 +5,6 @@ export class CslServiceClient {
 	constructor(private readonly _http: OauthRestService) { }
 
 	async clearCourseRecordCache(userId: string, courseId: string) {
-		await this._http.get(`/learner/${userId}/course_record/${courseId}`)
+		await this._http.get(`/reset-cache/learner/${userId}/course_record/${courseId}`)
 	}
 }

--- a/src/csl-service/client.ts
+++ b/src/csl-service/client.ts
@@ -7,4 +7,8 @@ export class CslServiceClient {
 	async clearCourseRecordCache(userId: string, courseId: string) {
 		await this._http.get(`/reset-cache/learner/${userId}/course_record/${courseId}`)
 	}
+
+	async clearCourseCache(courseId: string) {
+		await this._http.get(`/reset-cache/course/${courseId}`)
+	}
 }

--- a/src/csl-service/cslServiceConfig.ts
+++ b/src/csl-service/cslServiceConfig.ts
@@ -1,0 +1,3 @@
+export class CslServiceConfig {
+	constructor(public url: string, public timeout: number) { }
+}

--- a/src/learner-record/model/factory/courseRecordPatchFactory.ts
+++ b/src/learner-record/model/factory/courseRecordPatchFactory.ts
@@ -1,21 +1,6 @@
-import moment = require("moment")
 import { JsonPatch } from "../../../models/JsonPatch"
-import { CourseRecordPreference } from "../courseRecord/courseRecord"
 import { RecordState } from "../record"
-
-
-export function clearState() {
-	return JsonPatch.removePatch('state')
-}
 
 export function setState(state: RecordState) {
 	return JsonPatch.replacePatch('state', state)
-}
-
-export function setLastUpdated(lastUpdated: Date = new Date()) {
-	return JsonPatch.replacePatch('lastUpdated', moment(lastUpdated).format('YYYY-MM-DDTHH:mm:ss'))
-}
-
-export function setPreference(preference: CourseRecordPreference) {
-	return JsonPatch.replacePatch('preference', preference)
 }

--- a/src/learner-record/model/factory/moduleRecordPatchFactory.ts
+++ b/src/learner-record/model/factory/moduleRecordPatchFactory.ts
@@ -26,10 +26,6 @@ function setDate(key: string, date?: Date) {
 	return JsonPatch.replacePatch(key, convertedDate)
 }
 
-export function setUpdatedAt(updatedAt: Date) {
-	return setDate('updatedAt', updatedAt)
-}
-
 export function setBookingStatus(status: BookingStatus) {
 	return JsonPatch.replacePatch('bookingStatus', status.toString())
 }

--- a/src/learner-record/workers/actionWorkerService.ts
+++ b/src/learner-record/workers/actionWorkerService.ts
@@ -6,12 +6,14 @@ import { ApproveBookingActionWorker } from "./approveBookingActionWorker";
 import { CancelBookingActionWorker } from "./cancelBookingActionWorker";
 import { EventActionWorker } from "./eventActionWorker";
 import { WorkerAction } from "./WorkerAction";
+import {CslServiceClient} from '../../csl-service/client'
 
 export class ActionWorkerService {
     constructor(private learningCatalogue: LearningCatalogue,
         private civilServantRegistry: CsrsService,
         private learnerRecordAPI: LearnerRecord,
-        private organisationalUnitService: OrganisationalUnitService
+        private organisationalUnitService: OrganisationalUnitService,
+        private cslService: CslServiceClient
         ) {}
 
     private workers: Map<WorkerAction, EventActionWorker>
@@ -21,12 +23,14 @@ export class ActionWorkerService {
         this.workers.set(WorkerAction.APPROVED_BOOKING, new ApproveBookingActionWorker(this.learningCatalogue,
             this.civilServantRegistry,
             this.organisationalUnitService,
-            this.learnerRecordAPI))
+            this.learnerRecordAPI,
+            this.cslService))
 
         this.workers.set(WorkerAction.CANCEL_BOOKING, new CancelBookingActionWorker(this.learningCatalogue,
             this.civilServantRegistry,
             this.organisationalUnitService,
-            this.learnerRecordAPI))
+            this.learnerRecordAPI,
+            this.cslService))
     }
 
     getWorker(action: WorkerAction) {

--- a/src/learner-record/workers/approveBookingActionWorker.ts
+++ b/src/learner-record/workers/approveBookingActionWorker.ts
@@ -3,8 +3,8 @@ import { Course } from "../../learning-catalogue/model/course";
 import { Event } from "../../learning-catalogue/model/event";
 import { Module } from "../../learning-catalogue/model/module";
 import { CourseRecord } from "../model/courseRecord/courseRecord";
-import { setLastUpdated, setState } from "../model/factory/courseRecordPatchFactory";
-import { clearField, setEventDate, setEventId, setUpdatedAt } from "../model/factory/moduleRecordPatchFactory";
+import { setState } from "../model/factory/courseRecordPatchFactory";
+import { clearField, setEventDate, setEventId } from "../model/factory/moduleRecordPatchFactory";
 import { ModuleRecord } from "../model/moduleRecord/moduleRecord";
 import { RecordState } from "../model/record";
 import { EventActionWorker } from "./eventActionWorker";
@@ -22,11 +22,10 @@ export class ApproveBookingActionWorker extends EventActionWorker {
     }
 
     async updateCourseRecord(userId: string, courseRecord: CourseRecord): Promise<void> {
-        const patches = [setLastUpdated(new Date())]
         if (courseRecord.isNull() || !courseRecord.isInProgress()) {
-            patches.push(setState(RecordState.Approved))
+            const patches = [setState(RecordState.Approved)]
+            await this.learnerRecordAPI.patchCourseRecord(patches, userId, courseRecord.courseId)
         }
-        await this.learnerRecordAPI.patchCourseRecord(patches, userId, courseRecord.courseId)
     }
 
     async updateModuleRecord(moduleRecord: ModuleRecord, event: Event): Promise<ModuleRecord> {
@@ -36,8 +35,7 @@ export class ApproveBookingActionWorker extends EventActionWorker {
             clearField('score'),
             clearField('completionDate'),
             setEventId(event.id),
-            setEventDate(moment(event.dateRanges[0].date).toDate()),
-            setUpdatedAt(new Date())
+            setEventDate(moment(event.dateRanges[0].date).toDate())
         ]
         return await this.learnerRecordAPI.patchModuleRecord(patches, moduleRecord.id)
     }

--- a/src/learner-record/workers/eventActionWorker.ts
+++ b/src/learner-record/workers/eventActionWorker.ts
@@ -1,23 +1,22 @@
-import {LearnerRecord} from '..'
-import {CsrsService} from '../../csrs/service/csrsService'
-import {LearningCatalogue} from '../../learning-catalogue'
-import {Course} from '../../learning-catalogue/model/course'
-import {Event} from '../../learning-catalogue/model/event'
-import {FaceToFaceModule} from '../../learning-catalogue/model/faceToFaceModule'
-import {Module} from '../../learning-catalogue/model/module'
-import {ModuleNotFoundError} from 'lib/exception/moduleNotFound'
-import {EventNotFoundError} from 'lib/exception/eventNotFound'
-import {getLogger} from '../../utils/logger'
-import {CourseRecord} from '../model/courseRecord/courseRecord'
-import {CourseRecordInput} from '../model/courseRecord/courseRecordInput'
-import {ModuleRecord} from '../model/moduleRecord/moduleRecord'
-import {ModuleRecordInput} from '../model/moduleRecord/moduleRecordInput'
-import {RecordState} from '../model/record'
-import {WorkerAction} from './WorkerAction'
-import {CivilServant} from '../../csrs/model/civilServant'
-import {OrganisationalUnitService} from '../../csrs/service/organisationalUnitService'
-import {CslServiceClient} from '../../csl-service/client'
-
+import { LearnerRecord } from "..";
+import { CsrsService } from "../../csrs/service/csrsService";
+import { LearningCatalogue } from "../../learning-catalogue";
+import { Course } from "../../learning-catalogue/model/course";
+import { Event } from "../../learning-catalogue/model/event";
+import { FaceToFaceModule } from "../../learning-catalogue/model/faceToFaceModule";
+import { Module } from "../../learning-catalogue/model/module";
+import { ModuleNotFoundError } from "../../lib/exception/moduleNotFound";
+import { EventNotFoundError } from "../../lib/exception/eventNotFound";
+import { getLogger } from "../../utils/logger";
+import { CourseRecord } from "../model/courseRecord/courseRecord";
+import { CourseRecordInput } from "../model/courseRecord/courseRecordInput";
+import { ModuleRecord } from "../model/moduleRecord/moduleRecord";
+import { ModuleRecordInput } from "../model/moduleRecord/moduleRecordInput";
+import { RecordState } from "../model/record";
+import { WorkerAction } from "./WorkerAction";
+import { CivilServant } from "../../csrs/model/civilServant";
+import { OrganisationalUnitService } from "../../csrs/service/organisationalUnitService";
+import {CslServiceClient} from '../../csl-service/client';
 
 export abstract class EventActionWorker {
 

--- a/src/learning-catalogue/index.ts
+++ b/src/learning-catalogue/index.ts
@@ -17,6 +17,7 @@ import {Event} from './model/event'
 import {Audience} from './model/audience'
 import {Auth} from '../identity/auth'
 import {OauthRestService} from '../lib/http/oauthRestService'
+import {CslServiceClient} from '../csl-service/client'
 
 export class LearningCatalogue {
 	private _eventService: EntityService<Event>
@@ -27,8 +28,9 @@ export class LearningCatalogue {
 	private _cancellationPolicyService: EntityService<CancellationPolicy>
 	private _termsAndConditionsService: EntityService<TermsAndConditions>
 	private _restService: OauthRestService
+	private _cslService: CslServiceClient
 
-	constructor(config: LearningCatalogueConfig, auth: Auth) {
+	constructor(config: LearningCatalogueConfig, auth: Auth, cslService: CslServiceClient) {
 		this._restService = new OauthRestService(config, auth)
 
 		this._eventService = new EntityService<Event>(this._restService, new EventFactory())
@@ -44,6 +46,8 @@ export class LearningCatalogue {
 		this._cancellationPolicyService = new EntityService<CancellationPolicy>(this._restService, new CancellationPolicyFactory())
 
 		this._termsAndConditionsService = new EntityService<TermsAndConditions>(this._restService, new TermsAndConditionsFactory())
+
+		this._cslService = cslService
 	}
 
 	async listCourses(page: number = 0, size: number = 10): Promise<DefaultPageResults<Course>> {
@@ -61,14 +65,17 @@ export class LearningCatalogue {
 	}
 
 	async updateCourse(course: Course): Promise<Course> {
+		await this._cslService.clearCourseCache(course.id)
 		return this._courseService.update(`/courses/${course.id}`, course)
 	}
 
 	async publishCourse(course: Course): Promise<Course> {
+		await this._cslService.clearCourseCache(course.id)
 		return this._courseService.update(`/courses/${course.id}/publish`, course)
 	}
 
 	async archiveCourse(course: Course): Promise<Course> {
+		await this._cslService.clearCourseCache(course.id)
 		return this._courseService.update(`/courses/${course.id}/archive`, course)
 	}
 
@@ -77,6 +84,7 @@ export class LearningCatalogue {
 	}
 
 	async createModule(courseId: string, module: Module): Promise<Module> {
+		await this._cslService.clearCourseCache(courseId)
 		return this._moduleService.create(`/courses/${courseId}/modules/`, module)
 	}
 
@@ -85,14 +93,17 @@ export class LearningCatalogue {
 	}
 
 	async updateModule(courseId: string, module: Module): Promise<Module> {
+		await this._cslService.clearCourseCache(courseId)
 		return this._moduleService.update(`/courses/${courseId}/modules/${module.id}`, module)
 	}
 
 	async deleteModule(courseId: string, moduleId: string) {
+		await this._cslService.clearCourseCache(courseId)
 		return this._moduleService.delete(`/courses/${courseId}/modules/${moduleId}`)
 	}
 
 	async createEvent(courseId: string, moduleId: string, event: Event): Promise<Event> {
+		await this._cslService.clearCourseCache(courseId)
 		return this._eventService.create(`/courses/${courseId}/modules/${moduleId}/events`, event)
 	}
 
@@ -101,10 +112,12 @@ export class LearningCatalogue {
 	}
 
 	async updateEvent(courseId: string, moduleId: string, eventId: string, event: Event): Promise<Event> {
+		await this._cslService.clearCourseCache(courseId)
 		return this._eventService.update(`/courses/${courseId}/modules/${moduleId}/events/${eventId}`, event)
 	}
 
 	async createAudience(courseId: string, audience: Audience) {
+		await this._cslService.clearCourseCache(courseId)
 		return this._audienceService.create(`/courses/${courseId}/audiences`, audience)
 	}
 
@@ -113,10 +126,12 @@ export class LearningCatalogue {
 	}
 
 	async updateAudience(courseId: string, audience: Audience): Promise<Audience> {
+		await this._cslService.clearCourseCache(courseId)
 		return this._audienceService.update(`/courses/${courseId}/audiences/${audience.id}`, audience)
 	}
 
 	async deleteAudience(courseId: string, audienceId: string) {
+		await this._cslService.clearCourseCache(courseId)
 		return this._audienceService.delete(`/courses/${courseId}/audiences/${audienceId}`)
 	}
 

--- a/test/unit/learner-record/workers/actionWorkerServiceTest.ts
+++ b/test/unit/learner-record/workers/actionWorkerServiceTest.ts
@@ -1,17 +1,16 @@
-import * as chai from 'chai';
+import * as chai from 'chai'
 import {expect} from 'chai'
-import * as chaiAsPromised from 'chai-as-promised';
-import * as sinonChai from 'sinon-chai';
+import * as chaiAsPromised from 'chai-as-promised'
+import * as sinonChai from 'sinon-chai'
 
-import { CsrsService } from '../../../../src/csrs/service/csrsService';
-import { OrganisationalUnitService } from '../../../../src/csrs/service/organisationalUnitService';
-import { LearnerRecord } from '../../../../src/learner-record';
-import { ActionWorkerService } from '../../../../src/learner-record/workers/actionWorkerService';
-import {
-    CancelBookingActionWorker
-} from '../../../../src/learner-record/workers/cancelBookingActionWorker';
-import { WorkerAction } from '../../../../src/learner-record/workers/WorkerAction';
-import { LearningCatalogue } from '../../../../src/learning-catalogue';
+import {CsrsService} from '../../../../src/csrs/service/csrsService'
+import {OrganisationalUnitService} from '../../../../src/csrs/service/organisationalUnitService'
+import {LearnerRecord} from '../../../../src/learner-record'
+import {ActionWorkerService} from '../../../../src/learner-record/workers/actionWorkerService'
+import {CancelBookingActionWorker} from '../../../../src/learner-record/workers/cancelBookingActionWorker'
+import {WorkerAction} from '../../../../src/learner-record/workers/WorkerAction'
+import {LearningCatalogue} from '../../../../src/learning-catalogue'
+import {CslServiceClient} from '../../../../src/csl-service/client'
 
 chai.use(chaiAsPromised)
 chai.use(sinonChai)
@@ -23,8 +22,9 @@ describe('Tests for actionWorkerService', () => {
         const csrs = <CsrsService>{}
 		const learnerRecordApi = <LearnerRecord>{}
         const organisationalUnitService = <OrganisationalUnitService>{}
+        const cslService = <CslServiceClient>{}
 
-        const service = new ActionWorkerService(learningCatalogue, csrs, learnerRecordApi, organisationalUnitService)
+        const service = new ActionWorkerService(learningCatalogue, csrs, learnerRecordApi, organisationalUnitService, cslService)
         service.init()
         const worker = service.getWorker(WorkerAction.CANCEL_BOOKING)
         expect(worker).instanceOf(CancelBookingActionWorker)

--- a/test/unit/learner-record/workers/actionWorkerServiceTest.ts
+++ b/test/unit/learner-record/workers/actionWorkerServiceTest.ts
@@ -3,14 +3,16 @@ import {expect} from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 import * as sinonChai from 'sinon-chai'
 
-import {CsrsService} from '../../../../src/csrs/service/csrsService'
-import {OrganisationalUnitService} from '../../../../src/csrs/service/organisationalUnitService'
-import {LearnerRecord} from '../../../../src/learner-record'
-import {ActionWorkerService} from '../../../../src/learner-record/workers/actionWorkerService'
-import {CancelBookingActionWorker} from '../../../../src/learner-record/workers/cancelBookingActionWorker'
-import {WorkerAction} from '../../../../src/learner-record/workers/WorkerAction'
-import {LearningCatalogue} from '../../../../src/learning-catalogue'
-import {CslServiceClient} from '../../../../src/csl-service/client'
+import { CsrsService } from '../../../../src/csrs/service/csrsService';
+import { OrganisationalUnitService } from '../../../../src/csrs/service/organisationalUnitService';
+import { LearnerRecord } from '../../../../src/learner-record';
+import { ActionWorkerService } from '../../../../src/learner-record/workers/actionWorkerService';
+import {
+    CancelBookingActionWorker
+} from '../../../../src/learner-record/workers/cancelBookingActionWorker';
+import { WorkerAction } from '../../../../src/learner-record/workers/WorkerAction';
+import { LearningCatalogue } from '../../../../src/learning-catalogue';
+import {CslServiceClient} from '../../../../src/csl-service/client';
 
 chai.use(chaiAsPromised)
 chai.use(sinonChai)

--- a/test/unit/learner-record/workers/eventWorkersTest.ts
+++ b/test/unit/learner-record/workers/eventWorkersTest.ts
@@ -23,6 +23,7 @@ import {DateRange} from '../../../../src/learning-catalogue/model/dateRange'
 import {Event} from '../../../../src/learning-catalogue/model/event'
 import {FaceToFaceModule} from '../../../../src/learning-catalogue/model/faceToFaceModule'
 import {JsonPatchInterface} from '../../../../src/models/JsonPatch'
+import {CslServiceClient} from '../../../../src/csl-service/client'
 
 chai.use(chaiAsPromised)
 chai.use(sinonChai)
@@ -87,6 +88,9 @@ learnerRecordAPI.createCourseRecord.resolves()
 learnerRecordAPI.createModuleRecord.resolves()
 learnerRecordAPI.patchCourseRecord.resolves()
 learnerRecordAPI.patchModuleRecord.resolves()
+
+const cslService = sinon.createStubInstance(CslServiceClient)
+cslService.clearCourseRecordCache.resolves()
 
 const genericCourseRecord = (required: boolean, recordState?: RecordState) => {
 	return new CourseRecord(testCourseID, testUserID, recordState, [], testCourseTitle, required)
@@ -162,6 +166,7 @@ describe('Tests for the event action workers', () => {
 		learnerRecordAPI.createModuleRecord.reset()
 		learnerRecordAPI.patchCourseRecord.reset()
 		learnerRecordAPI.patchModuleRecord.reset()
+		cslService.clearCourseRecordCache.reset()
 	})
 
 	describe('Tests for the approve booking action worker', () => {
@@ -169,7 +174,7 @@ describe('Tests for the event action workers', () => {
 
 		beforeEach(() => {
 			worker = new ApproveBookingActionWorker(learningCatalogue as any, civilServantRegistry as any,
-                organisationalUnitService as any, learnerRecordAPI as any)
+                organisationalUnitService as any, learnerRecordAPI as any, cslService as any)
 		})
 
 		it('Should correctly create a course record', async () => {
@@ -178,6 +183,7 @@ describe('Tests for the event action workers', () => {
 			await worker.applyActionToLearnerRecord(testUserID, testCourseID, testModuleID, testEventID)
 
 			assertCreateCourseRecord(true, RecordState.Approved, RecordState.Approved)
+			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
 
 		it('Should correctly create a module record', async () => {
@@ -185,6 +191,7 @@ describe('Tests for the event action workers', () => {
 			await worker.applyActionToLearnerRecord(testUserID, testCourseID, testModuleID, testEventID)
 
 			assertCreateModuleRecord(RecordState.Approved)
+			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
 
 		it('Should correctly update the course record when the state is null', async () => {
@@ -195,6 +202,7 @@ describe('Tests for the event action workers', () => {
 				{op: 'replace', path: '/lastUpdated', value: testDateAsStr},
 				{op: 'replace', path: '/state', value: 'APPROVED'},
 			])
+			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
 
 		it('Should NOT update the course record when the state is in progress', async () => {
@@ -202,6 +210,7 @@ describe('Tests for the event action workers', () => {
 			await worker.applyActionToLearnerRecord(testUserID, testCourseID, testModuleID, testEventID)
 
 			expect(learnerRecordAPI.createCourseRecord.notCalled).to.be.true
+			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
 
 		it('Should correctly update the module record when the state is null', async () => {
@@ -219,6 +228,7 @@ describe('Tests for the event action workers', () => {
 				{op: 'replace', path: '/eventDate', value: testDateAsStr},
 				{op: 'replace', path: '/updatedAt', value: testDateAsStr},
 			])
+			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
 	})
 
@@ -227,13 +237,14 @@ describe('Tests for the event action workers', () => {
 
 		beforeEach(() => {
 			worker = new CancelBookingActionWorker(learningCatalogue as any, civilServantRegistry as any,
-                organisationalUnitService as any, learnerRecordAPI as any)
+                organisationalUnitService as any, learnerRecordAPI as any, cslService as any)
 		})
 		it('Should correctly create a course record', async () => {
 			learnerRecordAPI.getCourseRecord.resolves(undefined)
 			await worker.applyActionToLearnerRecord(testUserID, testCourseID, testModuleID, testEventID)
 
 			assertCreateCourseRecord(true, RecordState.Unregistered, RecordState.Unregistered)
+			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
 
 		it('Should correctly create a module record', async () => {
@@ -241,6 +252,7 @@ describe('Tests for the event action workers', () => {
 			await worker.applyActionToLearnerRecord(testUserID, testCourseID, testModuleID, testEventID)
 
 			assertCreateModuleRecord(RecordState.Unregistered)
+			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
 
 		it('Should correctly update the course record when the state is null', async () => {
@@ -251,6 +263,7 @@ describe('Tests for the event action workers', () => {
 				{op: 'replace', path: '/lastUpdated', value: testDateAsStr},
 				{op: 'replace', path: '/state', value: 'UNREGISTERED'},
 			])
+			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
 
 		it('Should NOT update the course record when the state is in progress', async () => {
@@ -258,6 +271,7 @@ describe('Tests for the event action workers', () => {
 			await worker.applyActionToLearnerRecord(testUserID, testCourseID, testModuleID, testEventID)
 
 			expect(learnerRecordAPI.createCourseRecord.notCalled).to.be.true
+			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
 
 		it('Should correctly update the module record when the state is null', async () => {
@@ -274,6 +288,7 @@ describe('Tests for the event action workers', () => {
 				{op: 'replace', path: '/updatedAt', value: testDateAsStr},
 				{op: 'replace', path: '/bookingStatus', value: 'CANCELLED'},
 			])
+			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
 	})
 })

--- a/test/unit/learner-record/workers/eventWorkersTest.ts
+++ b/test/unit/learner-record/workers/eventWorkersTest.ts
@@ -199,7 +199,6 @@ describe('Tests for the event action workers', () => {
 			await worker.applyActionToLearnerRecord(testUserID, testCourseID, testModuleID, testEventID)
 
 			assertPatchCourseRecord([
-				{op: 'replace', path: '/lastUpdated', value: testDateAsStr},
 				{op: 'replace', path: '/state', value: 'APPROVED'},
 			])
 			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
@@ -226,7 +225,6 @@ describe('Tests for the event action workers', () => {
 				{op: 'remove', path: '/completionDate', value: undefined},
 				{op: 'replace', path: '/eventId', value: testEventID},
 				{op: 'replace', path: '/eventDate', value: testDateAsStr},
-				{op: 'replace', path: '/updatedAt', value: testDateAsStr},
 			])
 			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
 		})
@@ -260,7 +258,6 @@ describe('Tests for the event action workers', () => {
 			await worker.applyActionToLearnerRecord(testUserID, testCourseID, testModuleID, testEventID)
 
 			assertPatchCourseRecord([
-				{op: 'replace', path: '/lastUpdated', value: testDateAsStr},
 				{op: 'replace', path: '/state', value: 'UNREGISTERED'},
 			])
 			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)
@@ -285,7 +282,6 @@ describe('Tests for the event action workers', () => {
 				{op: 'remove', path: '/result', value: undefined},
 				{op: 'remove', path: '/score', value: undefined},
 				{op: 'remove', path: '/completionDate', value: undefined},
-				{op: 'replace', path: '/updatedAt', value: testDateAsStr},
 				{op: 'replace', path: '/bookingStatus', value: 'CANCELLED'},
 			])
 			assertOneCallAndGetArgs(cslService.clearCourseRecordCache)

--- a/test/unit/learning-catalogue/indexTest.ts
+++ b/test/unit/learning-catalogue/indexTest.ts
@@ -15,6 +15,7 @@ import {EntityService} from '../../../src/learning-catalogue/service/entityServi
 import {Auth} from '../../../src/identity/auth'
 import {Event} from '../../../src/learning-catalogue/model/event'
 import {Audience} from '../../../src/learning-catalogue/model/audience'
+import {CslServiceClient} from '../../../src/csl-service/client'
 
 chai.use(chaiAsPromised)
 chai.use(sinonChai)
@@ -27,6 +28,7 @@ describe('Learning Catalogue tests', () => {
 	let cancellationPolicyService: EntityService<CancellationPolicy>
 	let termsAndConditionsService: EntityService<TermsAndConditions>
 	let eventService: EntityService<Event>
+	let cslService: CslServiceClient
 
 	const config = new LearningCatalogueConfig('http://example.org', 60000)
 
@@ -40,8 +42,10 @@ describe('Learning Catalogue tests', () => {
 		learningProviderService = <EntityService<LearningProvider>>{}
 		cancellationPolicyService = <EntityService<CancellationPolicy>>{}
 		termsAndConditionsService = <EntityService<TermsAndConditions>>{}
+		cslService = <CslServiceClient>{}
+		cslService.clearCourseCache = sinon.stub()
 
-		learningCatalogue = new LearningCatalogue(config, {} as Auth)
+		learningCatalogue = new LearningCatalogue(config, {} as Auth, cslService)
 		learningCatalogue.courseService = courseService
 		learningCatalogue.moduleService = moduleService
 		learningCatalogue.eventService = eventService


### PR DESCRIPTION
- Introduce csl-service client
- Booking actions now clear the csl-service client course record cache for the specified user
- Course authoring actions now clear the csl-service course cache
- Remove updating timestamps for events (this is handled in learner record now via DB updates)