### PR TITLE
LC-2724: MVP course completion report: Graph export

### DIFF
--- a/src/controllers/reporting/courseCompletionsController.ts
+++ b/src/controllers/reporting/courseCompletionsController.ts
@@ -1,4 +1,4 @@
-import {getRequest, postRequestWithBody, Route} from '../route'
+import {getRequest, postRequest, postRequestWithBody, Route} from '../route'
 import {NextFunction, Request, Response} from 'express'
 import {ReportService} from '../../report-service'
 import {ChooseCoursesModel} from './model/chooseCoursesModel'
@@ -8,6 +8,8 @@ import {Controller} from '../controller'
 import {CompoundRoleBase, mvpReportingRole} from '../../identity/identity'
 import {fetchCourseCompletionSessionObject, saveCourseCompletionSessionObject} from './utils'
 import {GetCourseAggregationParameters} from '../../report-service/model/getCourseAggregationParameters'
+import moment = require('moment')
+import { CourseCompletionsSession } from './model/courseCompletionsSession'
 
 export class CourseCompletionsController extends Controller {
 
@@ -50,7 +52,10 @@ export class CourseCompletionsController extends Controller {
 						behaviour: BehaviourOnError.REDIRECT,
 						path: '/reporting/course-completions/choose-courses'
 					}
-				}, [this.checkForOrgIdsInSessionMiddleware()])
+				}, [this.checkForOrgIdsInSessionMiddleware()]),
+
+			postRequest("/chart-csv", this.downloadDataAsCsv())
+
 		]
 	}
 
@@ -60,6 +65,10 @@ export class CourseCompletionsController extends Controller {
 			const pageModel = await this.reportService.getCourseCompletionsReportGraphPage(GetCourseAggregationParameters.createForDay(
 				session.courseIds!, session!.allOrganisationIds!.map(n => n.toString())
 			))
+			
+			session.chartData = pageModel.table
+			saveCourseCompletionSessionObject(session, request, () => {})
+			
 			response.render('page/reporting/courseCompletions/report', {pageModel,
 				backButton: '/reporting/course-completions/choose-courses'})
 		}
@@ -94,6 +103,41 @@ export class CourseCompletionsController extends Controller {
 			saveCourseCompletionSessionObject(session, request, async () => {
 				response.redirect('/reporting/course-completions')
 			})
+		}
+	}
+
+	public downloadDataAsCsv(){
+		return async (request: Request, response: Response) => {
+			const session: CourseCompletionsSession | undefined = fetchCourseCompletionSessionObject(request)
+			const chartData: {text: string}[][] | undefined = session?.chartData
+
+			const csvContent: string | undefined = chartData ? this.getCsvContentFromChartData(chartData) : undefined
+			
+			response.writeHead(200, this.getCsvResponseHeaders())
+			response.end(csvContent)
+		}
+	}
+
+	public getCsvContentFromChartData(chartData: {text: string}[][]){
+		const csvLines = chartData.map((row: any) => {
+			const time = row[0].text
+			const completions = row[1].text
+
+			const csvLine = `"${time}",${completions}`
+			return csvLine
+		})
+
+		csvLines?.unshift(`"time","completions"`)
+
+		const csvContent: string | undefined = csvLines?.join("\n")
+
+		return csvContent
+	}
+
+	private getCsvResponseHeaders(){
+		return {
+			'Content-type': 'text/csv',
+			'Content-disposition': `attachment;filename=course-completions-${moment().toISOString()}.csv`,
 		}
 	}
 }

--- a/src/controllers/reporting/courseCompletionsController.ts
+++ b/src/controllers/reporting/courseCompletionsController.ts
@@ -8,9 +8,9 @@ import {Controller} from '../controller'
 import {CompoundRoleBase, mvpReportingRole} from '../../identity/identity'
 import {fetchCourseCompletionSessionObject, saveCourseCompletionSessionObject} from './utils'
 import {GetCourseAggregationParameters} from '../../report-service/model/getCourseAggregationParameters'
-import moment = require('moment')
+import * as moment from 'moment'
 import { CourseCompletionsSession } from './model/courseCompletionsSession'
-import { getCsvContentFromData } from 'src/utils/dataToCsv'
+import { getCsvContentFromData } from '../../utils/dataToCsv'
 
 export class CourseCompletionsController extends Controller {
 

--- a/src/controllers/reporting/courseCompletionsController.ts
+++ b/src/controllers/reporting/courseCompletionsController.ts
@@ -10,6 +10,7 @@ import {fetchCourseCompletionSessionObject, saveCourseCompletionSessionObject} f
 import {GetCourseAggregationParameters} from '../../report-service/model/getCourseAggregationParameters'
 import moment = require('moment')
 import { CourseCompletionsSession } from './model/courseCompletionsSession'
+import { getCsvContentFromData } from 'src/utils/dataToCsv'
 
 export class CourseCompletionsController extends Controller {
 
@@ -109,29 +110,17 @@ export class CourseCompletionsController extends Controller {
 	public downloadDataAsCsv(){
 		return async (request: Request, response: Response) => {
 			const session: CourseCompletionsSession | undefined = fetchCourseCompletionSessionObject(request)
+			
 			const chartData: {text: string}[][] | undefined = session?.chartData
-
-			const csvContent: string | undefined = chartData ? this.getCsvContentFromChartData(chartData) : undefined
+			const fields = [
+				{name: "time", type: "text"},
+				{name: "completions", type: "number"}
+			]
+			const csvContent = chartData ? getCsvContentFromData(chartData, fields) : ""
 			
 			response.writeHead(200, this.getCsvResponseHeaders())
 			response.end(csvContent)
 		}
-	}
-
-	public getCsvContentFromChartData(chartData: {text: string}[][]){
-		const csvLines = chartData.map((row: any) => {
-			const time = row[0].text
-			const completions = row[1].text
-
-			const csvLine = `"${time}",${completions}`
-			return csvLine
-		})
-
-		csvLines?.unshift(`"time","completions"`)
-
-		const csvContent: string | undefined = csvLines?.join("\n")
-
-		return csvContent
 	}
 
 	private getCsvResponseHeaders(){

--- a/src/controllers/reporting/model/courseCompletionsSession.ts
+++ b/src/controllers/reporting/model/courseCompletionsSession.ts
@@ -1,5 +1,5 @@
 export class CourseCompletionsSession {
-	constructor(public selectedOrganisationId?: number, public allOrganisationIds?: number[], public courseIds?: string[]) { }
+	constructor(public selectedOrganisationId?: number, public allOrganisationIds?: number[], public courseIds?: string[], public chartData?: {text: string}[][]) { }
 
 	hasSelectedOrganisations() {
 		return this.selectedOrganisationId !== undefined &&

--- a/src/utils/dataToCsv.ts
+++ b/src/utils/dataToCsv.ts
@@ -1,0 +1,18 @@
+export function getCsvContentFromData(data: {text: string}[][], fields: {name: string, type: string}[]): string{
+    
+    let csvOutput: string = ""
+
+    csvOutput = data.map((row: {text: string}[]) => {
+        return row
+            .map((value: {text: string}) => value.text)
+            .map((value: string, index: number) => fields[index].type === "text" ? `"${value}"` : value)
+            .join(",")
+    })
+    .join("\n")
+
+    csvOutput = fields
+        .map((field: {name: string, type: string}) => field.name)
+        .map((field: string) => `"${field}"`).join(",") + "\n" + csvOutput
+
+    return csvOutput
+}

--- a/test/unit/controllers/reporting/courseCompletionsControllerTest.ts
+++ b/test/unit/controllers/reporting/courseCompletionsControllerTest.ts
@@ -168,22 +168,6 @@ describe('courseCompletionsController tests', () => {
 
 					expect(res.status).to.eql(401)
 				})
-
-				it('getCsvContentFromChartData returns the CSV text correctly from chart data', () => {
-					const chartData: {text: string} [][] = [
-						[{text: "1AM"}, {text: "0"}],
-						[{text: "2AM"}, {text: "1"}],
-						[{text: "3AM"}, {text: "2"}]
-					]
-
-					const expectedCSV = `"time","completions"
-"1AM",0
-"2AM",1
-"3AM",2`
-					const actualCSV = controller.getCsvContentFromChartData(chartData)
-
-					expect(actualCSV).to.be.eql(expectedCSV)
-				})
 			})
 			
 		})

--- a/test/utils/dataToCsvTest.ts
+++ b/test/utils/dataToCsvTest.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai'
+import { getCsvContentFromData } from '../../src/utils/dataToCsv'
+
+describe('Data To CSV Util', () => {
+    it('should turn data into CSV text', () => {
+        const data = [
+            [{text: "1AM"}, {text: "0"}],
+            [{text: "2AM"}, {text: "1"}],
+            [{text: "3AM"}, {text: "2"}]
+        ]
+
+        const fields = [
+            {name: "time", type: "text"},
+            {name: "completions", type: "number"}
+        ]
+
+        const expectedCsvContent = `"time","completions"
+"1AM",0
+"2AM",1
+"3AM",2`
+
+        const actualCsvContent = getCsvContentFromData(data, fields)
+
+        expect(actualCsvContent).to.eql(expectedCsvContent)
+    })
+})

--- a/views/component/chart/template.njk
+++ b/views/component/chart/template.njk
@@ -1,11 +1,21 @@
 {% from "tabs/macro.njk" import govukTabs %}
 {% from "table/macro.njk" import govukTable %}
+{% from "button/macro.njk" import govukButton %}
 
 <div class='chart-container hidden'>
     <script data-chart='settings' type="json">{{settings|dump|safe}}</script>
     {% set chartHtml %}
         <h2 class="govuk-heading-s">Chart</h2>
         <canvas class='chart' tabindex="0" data-chart='canvas' id="{{ id }}"></canvas>
+        <div style="margin-top: 45px">
+        <form action="/reporting/course-completions/chart-csv" method="post">
+            {{ govukButton({
+                text: "Download chart data (.csv)",
+                preventDoubleClick: true,
+                type: submit
+            }) }}
+        </form>
+        </div>
     {% endset -%}
     {% set tableHtml %}
         <h2 class="govuk-heading-s">Table</h2>


### PR DESCRIPTION
This change:

* Adds the chart data to the session
* Creates a new Util `dataToCsv` to convert the chart data to a CSV string.
* Creates a new endpoint `POST /reporting/course-completions/chart-csv` which converts the chart data from the session, converts it into CSV format using the util, and downloads it.
* Adds a green button under the chart which submits a `POST` request to the new endpoint to download the CSV data as a file.