### PR TITLE
LC-1297-Remove the "Platform" keyword from “Civil Service Learning Platform“ on the CSL UI

### DIFF
--- a/views/component/Page.njk
+++ b/views/component/Page.njk
@@ -110,7 +110,7 @@
           text: "Accessibility statement"
         }
       ],
-      html: "<div><ul><li>Built by the <a class=\"govuk-footer__link\" href=\"#\">Civil Service Learning Platform</a></li></ul></div>"
+      html: "<div><ul><li>Built by the <a class=\"govuk-footer__link\" href=\"#\">Civil Service Learning</a></li></ul></div>"
     }
   }) }}
 {% endblock %}

--- a/views/component/Page.njk
+++ b/views/component/Page.njk
@@ -110,7 +110,7 @@
           text: "Accessibility statement"
         }
       ],
-      html: "<div><ul><li>Built by the <a class=\"govuk-footer__link\" href=\"#\">Civil Service Learning</a></li></ul></div>"
+      html: "<div><ul><li>Built by <a class=\"govuk-footer__link\" href=\"#\">Civil Service Learning</a></li></ul></div>"
     }
   }) }}
 {% endblock %}


### PR DESCRIPTION
Testing document: https://cshrdigitalandanalysis.atlassian.net/wiki/spaces/LPG/pages/3884089345/LC-1297-Remove+the+Platform+keyword+from+the+CSL+UI#lpg-management.1