### PR TITLE
LC 3429 cancel event

### DIFF
--- a/src/controllers/audience/audienceController.ts
+++ b/src/controllers/audience/audienceController.ts
@@ -44,7 +44,7 @@ export class AudienceController {
 	}
 
 	private configurePathParametersProcessing() {
-		applyLearningCatalogueMiddleware({getModule: false, audience: {csrsService: this.csrsService}}, this.router, this.learningCatalogue)
+		applyLearningCatalogueMiddleware({getModule: false, audience: {csrsService: this.csrsService}, getEvent: false}, this.router, this.learningCatalogue)
 	}
 
 	private setRouterPaths() {

--- a/src/controllers/courseController.ts
+++ b/src/controllers/courseController.ts
@@ -38,7 +38,7 @@ export class CourseController implements FormController {
 
 	/* istanbul ignore next */
 	private configureRouterPaths() {
-		applyLearningCatalogueMiddleware({getModule: false}, this.router, this.learningCatalogue)
+		applyLearningCatalogueMiddleware({getModule: false, getEvent: false}, this.router, this.learningCatalogue)
 		this.router.get('/content-management/courses/:courseId/overview', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.courseOverview()))
 		this.router.get('/content-management/courses/:courseId/preview', xss(), this.checkForEventViewRole(), this.coursePreview())
 

--- a/src/controllers/middleware/learningCatalogueMiddleware.ts
+++ b/src/controllers/middleware/learningCatalogueMiddleware.ts
@@ -4,9 +4,11 @@ import {Course} from '../../learning-catalogue/model/course'
 import {LearningCatalogue} from '../../learning-catalogue'
 import {Audience} from '../../learning-catalogue/model/audience'
 import {CsrsService} from '../../csrs/service/csrsService'
+import {Module} from '../../learning-catalogue/model/module'
 
 export interface LearningCatalogueMiddlewareSettings {
 	getModule: boolean,
+	getEvent?: boolean,
 	audience?: {
 		csrsService: CsrsService
 	}
@@ -15,9 +17,11 @@ export interface LearningCatalogueMiddlewareSettings {
 export function applyLearningCatalogueMiddleware(settings: LearningCatalogueMiddlewareSettings,
 												 router: Router, learningCatalogue: LearningCatalogue) {
 	let course: Course | null
+	let module: Module | undefined
 
 	router.param('courseId', async (req: Request, res: Response, next: NextFunction, courseId: string) => {
-		course = await learningCatalogue.getCourse(courseId)
+		const includeAvailability = settings.getEvent
+		course = await learningCatalogue.getCourse(courseId, includeAvailability)
 		if (course) {
 			res.locals.course = course
 			next()
@@ -29,7 +33,7 @@ export function applyLearningCatalogueMiddleware(settings: LearningCatalogueMidd
 	if (settings.getModule) {
 		router.param('moduleId', async (req: Request, res: Response, next: NextFunction, moduleId: string) => {
 			if (course) {
-				const module = course.getModule(moduleId)
+				module = course.getModule(moduleId)
 				if (module) {
 					const duration = moment.duration(module.duration, 'seconds')
 					res.locals.module = module
@@ -45,6 +49,23 @@ export function applyLearningCatalogueMiddleware(settings: LearningCatalogueMidd
 				return res.render("page/not-found")
 			}
 		})
+		if (settings.getEvent) {
+			router.param('eventId', async (req: Request, res: Response, next: NextFunction, eventId: string) => {
+				if (module) {
+					const event = module.events.find(e => e.id === eventId)
+					if (event) {
+						res.locals.event = event
+						res.locals.courseId = req.params.courseId
+						res.locals.moduleId = req.params.moduleId
+						next()
+					} else {
+						res.status(404)
+						return res.render("page/not-found")
+					}
+
+				}
+			})
+		}
 	}
 	const audienceSettings = settings.audience
 	if (audienceSettings !== undefined) {

--- a/src/controllers/module/event/eventController.ts
+++ b/src/controllers/module/event/eventController.ts
@@ -103,7 +103,7 @@ export class EventController implements FormController {
 
 		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId', xss(), asyncHandler(this.getAttendeeDetails()))
 
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId/update', xss(), asyncHandler(this.updateBooking()))
+		this.router.post('/content-management/courses/:courseUid/modules/:moduleUid/events/:eventUid/attendee/:bookingUid/update', xss(), asyncHandler(this.updateBooking()))
 
 		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/cancel', xss(), asyncHandler(this.cancelEvent()))
 		this.router.post('/content-management/courses/:courseUid/modules/:moduleUid/events/:eventUid/cancel', xss(), asyncHandler(this.setCancelEvent()))

--- a/src/controllers/module/event/eventController.ts
+++ b/src/controllers/module/event/eventController.ts
@@ -50,21 +50,18 @@ export class EventController implements FormController {
 
 	/* istanbul ignore next */
 	private setRouterPaths() {
-		this.router.param(
-			'eventId',
-			asyncHandler(async (req: Request, res: Response, next: NextFunction, eventId: string) => {
-				const event = await this.learningCatalogue.getEvent(req.params.courseId, req.params.moduleId, eventId)
-				if (event) {
-					res.locals.event = event
-					res.locals.courseId = req.params.courseId
-					res.locals.moduleId = req.params.moduleId
-					next()
-				} else {
-					res.status(404)
-					return res.render("page/not-found")
+
+		this.router.use(asyncHandler((req: Request, res: Response, next: NextFunction) => {
+			if (req.user && req.user.hasEventViewingRole()) {
+				next()
+			} else {
+				if (req.user && req.user.uid) {
+					this.logger.error('Rejecting user without event viewing role ' + req.user.uid + ' with IP '
+						+ req.ip + ' from page ' + req.originalUrl)
 				}
-			})
-		)
+				res.render('page/unauthorised')
+			}
+		}))
 
 		this.router.param(
 			'eventId',
@@ -80,55 +77,41 @@ export class EventController implements FormController {
 				}
 			})
 		)
-		applyLearningCatalogueMiddleware({getModule: true}, this.router, this.learningCatalogue)
+		applyLearningCatalogueMiddleware({getModule: true, getEvent: true}, this.router, this.learningCatalogue)
 
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/location/create', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.getLocation()))
+		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/location/create', xss(), asyncHandler(this.getLocation()))
 
-		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/location', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.editLocation()))
+		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/location', xss(), asyncHandler(this.editLocation()))
 
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/location/', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.setLocation()))
+		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/location/', xss(), asyncHandler(this.setLocation()))
 
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/location/:eventId', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.updateLocation()))
+		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/location/:eventId', xss(), asyncHandler(this.updateLocation()))
 
-		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events-preview/:eventId?', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.getDatePreview()))
-		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events-overview/:eventId', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.getEventOverview()))
+		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events-preview/:eventId?', xss(), asyncHandler(this.getDatePreview()))
+		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events-overview/:eventId', xss(), asyncHandler(this.getEventOverview()))
 
-		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.getDateTime()))
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.setDateTime()))
+		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/', xss(), asyncHandler(this.getDateTime()))
+		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/', xss(), asyncHandler(this.setDateTime()))
 
-		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/dateRanges/:dateRangeIndex', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.editDateRange()))
+		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/dateRanges/:dateRangeIndex', xss(), asyncHandler(this.editDateRange()))
 
-		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/dateRanges/', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.dateRangeOverview()))
+		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/dateRanges/', xss(), asyncHandler(this.dateRangeOverview()))
 
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/dateRanges/', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.addDateRange()))
+		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/dateRanges/', xss(), asyncHandler(this.addDateRange()))
 
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/dateRanges/:dateRangeIndex', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.updateDateRange()))
+		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/dateRanges/:dateRangeIndex', xss(), asyncHandler(this.updateDateRange()))
 
-		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.getAttendeeDetails()))
+		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId', xss(), asyncHandler(this.getAttendeeDetails()))
 
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId/update', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.updateBooking()))
+		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId/update', xss(), asyncHandler(this.updateBooking()))
 
-		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/cancel', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.cancelEvent()))
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/cancel', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.setCancelEvent()))
+		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/cancel', xss(), asyncHandler(this.cancelEvent()))
+		this.router.post('/content-management/courses/:courseUid/modules/:moduleUid/events/:eventUid/cancel', xss(), asyncHandler(this.setCancelEvent()))
 
-		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId/cancel', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.getCancelBooking()))
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId/cancel', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.cancelBooking()))
+		this.router.get('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId/cancel', xss(), asyncHandler(this.getCancelBooking()))
+		this.router.post('/content-management/courses/:courseUid/modules/:moduleUid/events/:eventUid/attendee/:bookingUid/cancel', xss(), asyncHandler(this.cancelBooking()))
 
-		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/invite', xss(), asyncHandler(this.checkForEventViewRole()), asyncHandler(this.inviteLearner()))
-	}
-
-	public checkForEventViewRole() {
-		return (req: Request, res: Response, next: NextFunction) => {
-			if (req.user && req.user.hasEventViewingRole()) {
-				next()
-			} else {
-				if (req.user && req.user.uid) {
-					this.logger.error('Rejecting user without event viewing role ' + req.user.uid + ' with IP '
-						+ req.ip + ' from page ' + req.originalUrl)
-					}
-				res.render('page/unauthorised')
-			}
-		}
+		this.router.post('/content-management/courses/:courseId/modules/:moduleId/events/:eventId/invite', xss(), asyncHandler(this.inviteLearner()))
 	}
 
 	public getDateTime() {
@@ -266,7 +249,7 @@ export class EventController implements FormController {
 						moduleId: moduleId,
 					})
 				} else {
-					const event = await this.learningCatalogue.getEvent(courseId, moduleId, eventId)
+					const event: Event = response.locals.event
 
 					event!.dateRanges!.push(dateRange)
 
@@ -326,7 +309,7 @@ export class EventController implements FormController {
 						dateRangeIndex: dateRangeIndex,
 					})
 				} else {
-					const event = await this.learningCatalogue.getEvent(courseId, moduleId, eventId)
+					const event: Event = response.locals.event
 					// @ts-ignore
 					event!.dateRanges![dateRangeIndex] = dateRange
 
@@ -432,7 +415,7 @@ export class EventController implements FormController {
 					errors: errors,
 				})
 			} else {
-				let event = await this.learningCatalogue.getEvent(req.params.courseId, req.params.moduleId, req.params.eventId)
+				let event: Event = res.locals.event
 
 				event.venue = data.venue
 
@@ -450,9 +433,6 @@ export class EventController implements FormController {
 
 	public getEventOverview() {
 		return async (req: Request, res: Response) => {
-			const course: Course = res.locals.course
-			const module: Module = res.locals.module
-
 			const event = res.locals.event
 			const eventDateWithMonthAsText: string = DateTime.convertDate(event.dateRanges[0].date)
 
@@ -462,8 +442,6 @@ export class EventController implements FormController {
 			res.render('page/course/module/events/events-overview', {
 				bookings: activeBookings,
 				eventDateWithMonthAsText,
-				course: course,
-				module: module,
 			})
 		}
 	}
@@ -481,11 +459,12 @@ export class EventController implements FormController {
 
 	public setCancelEvent() {
 		return async (req: Request, res: Response) => {
-			let event = res.locals.event
-			event.status = Event.Status.CANCELLED
+			const courseUid = req.params.courseUid
+			const moduleUid = req.params.moduleUid
+			const eventUid = req.params.eventUid
 
 			try {
-				await this.learnerRecord.cancelEvent(req.params.eventId, event, req.body.cancellationReason)
+				await this.cslService.cancelEvent(courseUid, moduleUid, eventUid, req.body.cancellationReason)
 			} catch (e) {
 				this.logger.info(`The event has no attendees: ${e}`)
 			}
@@ -495,7 +474,7 @@ export class EventController implements FormController {
 			}
 
 			return req.session!.save(() => {
-				res.redirect(`/content-management/courses/${req.params.courseId}/modules/${req.params.moduleId}/events-overview/${req.params.eventId}`)
+				res.redirect(`/content-management/courses/${courseUid}/modules/${moduleUid}/events-overview/${eventUid}`)
 			})
 		}
 	}
@@ -567,13 +546,13 @@ export class EventController implements FormController {
 
 	public updateBooking() {
 		return async (req: Request, res: Response) => {
-			const courseId = req.params.courseId
-			const moduleId = req.params.moduleId
-			const eventId = req.params.eventId
-			const bookingId = req.params.bookingId
+			const courseUid = req.params.courseUid
+			const moduleUid = req.params.moduleUid
+			const eventUid = req.params.eventUid
+			const bookingUid = req.params.bookingUid
 
-			await this.cslService.approveBooking(courseId, moduleId, eventId, bookingId)
-			return res.redirect(`/content-management/courses/${courseId}/modules/${moduleId}/events/${eventId}/attendee/${bookingId}`)
+			await this.cslService.approveBooking(courseUid, moduleUid, eventUid, bookingUid)
+			return res.redirect(`/content-management/courses/${courseUid}/modules/${moduleUid}/events/${eventUid}/attendee/${bookingUid}`)
 		}
 	}
 
@@ -602,7 +581,7 @@ export class EventController implements FormController {
 
 	@Validate({
 		fields: ['reason'],
-		redirect: `/content-management/courses/:courseId/modules/:moduleId/events/:eventId/attendee/:bookingId/cancel`,
+		redirect: `/content-management/courses/:courseUid/modules/:moduleUid/events/:eventUid/attendee/:bookingUid/cancel`,
 	})
 	public cancelBooking() {
 		return async (req: Request, res: Response) => {
@@ -610,14 +589,14 @@ export class EventController implements FormController {
 				...req.body,
 			}
 
-			const courseId = req.params.courseId
-			const moduleId = req.params.moduleId
-			const eventId = req.params.eventId
+			const courseUid = req.params.courseUid
+			const moduleUid = req.params.moduleUid
+			const eventUid = req.params.eventUid
 
-			await this.cslService.cancelBooking(courseId, moduleId, eventId,
-				req.params.bookingId, new CancelBookingDto(data.cancellationReason))
+			await this.cslService.cancelBooking(courseUid, moduleUid, eventUid,
+				req.params.bookingUid, new CancelBookingDto(data.cancellationReason))
 
-			return res.redirect(`/content-management/courses/${courseId}/modules/${moduleId}/events-overview/${eventId}`)
+			return res.redirect(`/content-management/courses/${courseUid}/modules/${moduleUid}/events-overview/${eventUid}`)
 		}
 	}
 	private findBooking(bookings: any, bookingId: number): Booking {

--- a/src/csl-service/client.ts
+++ b/src/csl-service/client.ts
@@ -55,4 +55,13 @@ export class CslServiceClient {
 	async downloadCourseCompletionsReport(urlSlug: string): Promise<ReportResponse> {
 		return await this._http.getFile(`${this.COURSE_COMPLETIONS_DOWNLOAD_SOURCE_URL}/${urlSlug}`)
 	}
+
+	async cancelEvent(courseId: string, moduleId: string, eventId: string, cancellationReason: string) {
+		return await this._http.postRequest({
+			url: `/admin/courses/${courseId}/modules/${moduleId}/events/${eventId}/cancel`,
+			data: {
+				reason: cancellationReason
+			}
+		})
+	}
 }

--- a/src/learner-record/index.ts
+++ b/src/learner-record/index.ts
@@ -4,7 +4,6 @@ import {Invite} from './model/invite'
 import {InviteFactory} from './model/factory/inviteFactory'
 import {Booking} from './model/booking'
 import {BookingFactory} from './model/factory/bookingFactory'
-import {Event} from '../learning-catalogue/model/event'
 import { getLogger } from '../utils/logger'
 import {RestServiceConfig} from 'lib/http/restServiceConfig'
 
@@ -56,17 +55,6 @@ export class LearnerRecord {
 
 	async inviteLearner(eventId: string, invite: Invite): Promise<Invite> {
 		return await this._restService.post(`/event/${eventId}/invitee`, invite)
-	}
-
-	async cancelEvent(eventId: string, event: Event, cancellationReason: String) {
-		try {
-			return await this._restService.patch(`/event/${eventId}`, {
-				status: event.status,
-				cancellationReason: cancellationReason,
-			})
-		} catch (e) {
-			throw new Error(`An error occurred when trying to cancel an event: ${e}`)
-		}
 	}
 
 	async createEvent(eventId: string, uri: string) {

--- a/src/learning-catalogue/index.ts
+++ b/src/learning-catalogue/index.ts
@@ -130,9 +130,9 @@ export class LearningCatalogue {
 		return course
 	}
 
-	async getCourse(courseId: string): Promise<Course|null> {
+	async getCourse(courseId: string, includeAvailability: boolean = false): Promise<Course|null> {
 		try {
-			return await this._courseService.get(`/courses/${courseId}`)
+			return await this._courseService.get(`/courses/${courseId}?includeAvailability=${includeAvailability}`)
 		} catch (e) {
 			if (e instanceof HttpException && e.statusCode === 404) {
 				return null
@@ -167,10 +167,6 @@ export class LearningCatalogue {
 	async createEvent(courseId: string, moduleId: string, event: Event): Promise<Event> {
 		await this._cslService.clearCourseCache(courseId)
 		return this._eventService.create(`/courses/${courseId}/modules/${moduleId}/events`, event)
-	}
-
-	async getEvent(courseId: string, moduleId: string, eventId: string): Promise<Event> {
-		return this._eventService.get(`/courses/${courseId}/modules/${moduleId}/events/${eventId}`)
 	}
 
 	async updateEvent(courseId: string, moduleId: string, eventId: string, event: Event): Promise<Event> {

--- a/src/learning-catalogue/model/event.ts
+++ b/src/learning-catalogue/model/event.ts
@@ -5,6 +5,8 @@ import {DateRange} from './dateRange'
 import {Venue} from './venue'
 import * as moment from 'moment'
 
+export type EventStatus = 'Active' | 'Cancelled'
+
 export class Event {
 	id: string
 
@@ -19,7 +21,7 @@ export class Event {
 	})
 	venue: Venue
 
-	status: Event.Status
+	status: EventStatus
 
 	cancellationReason: string
 
@@ -37,10 +39,4 @@ const extractDurationOfEvent = (dateRange: DateRange) => {
 	const endTime = moment(_.get(dateRange, 'endTime', 0), 'HH:mm')
 	const duration = moment.duration(endTime.diff(startTime))
 	return duration.asSeconds()
-}
-export namespace Event {
-	export enum Status {
-		ACTIVE = 'Active',
-		CANCELLED = 'Cancelled',
-	}
 }

--- a/src/learning-catalogue/model/factory/eventFactory.ts
+++ b/src/learning-catalogue/model/factory/eventFactory.ts
@@ -22,7 +22,7 @@ export class EventFactory {
 		event.dateRanges.sort((dateRange1, dateRange2) => DateTime.sortDateRanges(dateRange1, dateRange2))
 
 		event.venue = this.venueFactory.create(data.venue)
-		event.status = data.status ? Event.Status[data.status.toUpperCase() as keyof typeof Event.Status] : Event.Status.ACTIVE
+		event.status = data.status
 
 		event.cancellationReason = data.cancellationReason
 

--- a/src/learning-catalogue/model/module.ts
+++ b/src/learning-catalogue/model/module.ts
@@ -1,4 +1,5 @@
 import {IsIn, IsNotEmpty, IsOptional, IsPositive, Min} from 'class-validator'
+import {Event} from './event'
 
 export class Module {
 	id: string
@@ -48,6 +49,8 @@ export class Module {
 	cost?: number
 
 	optional: boolean
+
+	events: Event[]
 }
 
 export namespace Module {

--- a/test/unit/controllers/module/event/eventControllerTest.ts
+++ b/test/unit/controllers/module/event/eventControllerTest.ts
@@ -868,7 +868,7 @@ describe('EventController', function() {
 
 			dateRangeValidator.check = sinon.stub().returns(errors)
 
-			const event = {
+			response.locals.event = {
 				id: 'event-id',
 				venue: {
 					address: 'London',
@@ -881,8 +881,6 @@ describe('EventController', function() {
 				status: 'Active',
 				cancellationReason: 'The event is no longer available',
 			}
-
-			response.locals.event = event
 			learningCatalogue.updateEvent = sinon.stub().returns(Promise.reject(error))
 
 			await eventController.updateDateRange()(request, response, next)

--- a/test/unit/controllers/module/event/eventControllerTest.ts
+++ b/test/unit/controllers/module/event/eventControllerTest.ts
@@ -233,7 +233,7 @@ describe('EventController', function() {
 				id: 'event-id',
 				venue: venue,
 				dateRanges: [],
-				status: Event.Status.ACTIVE,
+				status: 'Active',
 				cancellationReason: 'The event is no longer available',
 			}
 
@@ -279,7 +279,7 @@ describe('EventController', function() {
 				id: 'event-id',
 				venue: venue,
 				dateRanges: [],
-				status: Event.Status.ACTIVE,
+				status: 'Active',
 				cancellationReason: 'The event is no longer available',
 			}
 			req.body = {
@@ -321,8 +321,7 @@ describe('EventController', function() {
 				capacity: 10,
 				minCapacity: 5,
 			}
-
-			const event = <Event>{
+			const event = {
 				id: 'event-id',
 				venue: {
 					location: 'London',
@@ -338,7 +337,7 @@ describe('EventController', function() {
 					},
 				],
 			}
-
+			res.locals.event = event
 			req.body = {
 				location: venue.location,
 				address: venue.address,
@@ -346,15 +345,11 @@ describe('EventController', function() {
 				minCapacity: venue.minCapacity,
 			}
 
-			event.venue = venue
-
 			eventValidator.check = sinon.stub().returns({fields: [], size: 0})
-			learningCatalogue.getEvent = sinon.stub().returns(event)
 			learningCatalogue.updateEvent = sinon.stub().returns(Promise.resolve())
 
 			await eventController.updateLocation()(req, res, next)
 
-			expect(learningCatalogue.getEvent).to.have.been.calledOnceWith(req.params.courseId, req.params.moduleId, req.params.eventId)
 			expect(learningCatalogue.updateEvent).to.have.been.calledOnceWith(req.params.courseId, req.params.moduleId, req.params.eventId, event)
 			expect(res.redirect).to.have.been.calledOnceWith(`/content-management/courses/course-id/modules/module-id/events-overview/event-id`)
 		})
@@ -557,11 +552,11 @@ describe('EventController', function() {
 		const request: Request = mockReq()
 		const response: Response = mockRes()
 
-		request.params.courseId = 'courseId'
-		request.params.moduleId = 'moduleId'
-		request.params.eventId = 'eventId'
+		request.params.courseUid = 'courseUid'
+		request.params.moduleUid = 'moduleUid'
+		request.params.eventUid = 'eventUid'
 		// @ts-ignore
-		request.params.bookingId = 99
+		request.params.bookingUid = 99
 
 		request.body.action = 'register'
 
@@ -569,8 +564,8 @@ describe('EventController', function() {
 
 		await registerLearner(request, response)
 
-		expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/courseId/modules/moduleId/events/eventId/attendee/99`)
-		expect(cslService.approveBooking).to.have.been.calledOnceWith('courseId', 'moduleId', 'eventId', 99)
+		expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/courseUid/modules/moduleUid/events/eventUid/attendee/99`)
+		expect(cslService.approveBooking).to.have.been.calledOnceWith('courseUid', 'moduleUid', 'eventUid', 99)
 	})
 
 	it('should change booking status to cancelled and redirect to event overview page', async function() {
@@ -579,11 +574,11 @@ describe('EventController', function() {
 		const request: Request = mockReq()
 		const response: Response = mockRes()
 
-		request.params.courseId = 'courseId'
-		request.params.moduleId = 'moduleId'
-		request.params.eventId = 'eventId'
+		request.params.courseUid = 'courseUid'
+		request.params.moduleUid = 'moduleUid'
+		request.params.eventUid = 'eventUid'
 		// @ts-ignore
-		request.params.bookingId = 99
+		request.params.bookingUid = 99
 
 		request.body.reason = 'cancel'
 
@@ -593,8 +588,8 @@ describe('EventController', function() {
 
 		await registerLearner(request, response)
 
-		expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/courseId/modules/moduleId/events-overview/eventId`)
-		expect(cslService.cancelBooking).to.have.been.calledOnceWith('courseId', 'moduleId', 'eventId', 99)
+		expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/courseUid/modules/moduleUid/events-overview/eventUid`)
+		expect(cslService.cancelBooking).to.have.been.calledOnceWith('courseUid', 'moduleUid', 'eventUid', 99)
 	})
 
 	it('should redirect to cancel attendee page if cancellation reason is not selected', async function() {
@@ -607,11 +602,11 @@ describe('EventController', function() {
 
 		const registerLearner: (request: Request, response: Response) => void = eventController.cancelBooking()
 
-		request.params.courseId = 'courseId'
-		request.params.moduleId = 'moduleId'
-		request.params.eventId = 'eventId'
+		request.params.courseUid = 'courseUid'
+		request.params.moduleUid = 'moduleUid'
+		request.params.eventUid = 'eventUid'
 		// @ts-ignore
-		request.params.bookingId = 99
+		request.params.bookingUid = 99
 
 		request.body.reason = ''
 
@@ -619,7 +614,7 @@ describe('EventController', function() {
 
 		await registerLearner(request, response)
 
-		expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/courseId/modules/moduleId/events/eventId/attendee/99/cancel`)
+		expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/courseUid/modules/moduleUid/events/eventUid/attendee/99/cancel`)
 	})
 
 	it('should render cancel event page', async function() {
@@ -647,21 +642,21 @@ describe('EventController', function() {
 
 		request.body.cancellationReason = 'reason'
 
-		request.params.eventId = 'eventId'
-		request.params.courseId = 'courseId'
-		request.params.moduleId = 'moduleId'
+		request.params.eventUid = 'eventUid'
+		request.params.courseUid = 'courseUid'
+		request.params.moduleUid = 'moduleUid'
 
 		response.locals.event = event
 
-		learnerRecord.cancelEvent = sinon.stub()
+		cslService.cancelEvent = sinon.stub()
 		request.session!.save = sinon
 			.stub()
-			.returns(response.redirect(`/content-management/courses/${request.params.courseId}/modules/${request.params.moduleId}/events-overview/${request.params.eventId}`))
+			.returns(response.redirect(`/content-management/courses/${request.params.courseUid}/modules/${request.params.moduleUid}/events-overview/${request.params.eventUid}`))
 
 		await eventController.setCancelEvent()(request, response)
 
-		expect(learnerRecord.cancelEvent).to.have.been.calledOnceWith('eventId', event, 'reason')
-		expect(response.redirect).to.have.been.calledOnceWith('/content-management/courses/courseId/modules/moduleId/events-overview/eventId')
+		expect(cslService.cancelEvent).to.have.been.calledOnceWith('courseUid', 'moduleUid', 'eventUid', 'reason')
+		expect(response.redirect).to.have.been.calledOnceWith('/content-management/courses/courseUid/modules/moduleUid/events-overview/eventUid')
 	})
 
 	it('should render cancel attendee page', async function() {
@@ -803,15 +798,15 @@ describe('EventController', function() {
 					availability: 5,
 				},
 				dateRanges: [],
-				status: Event.Status.ACTIVE,
+				status: 'Active',
 				cancellationReason: 'The event is no longer available',
 			}
-			learningCatalogue.getEvent = sinon.stub().returns(event)
+			response.locals.event = event
+
 			learningCatalogue.updateEvent = sinon.stub().returns(Promise.resolve(event))
 
 			await eventController.updateDateRange()(request, response, next)
 
-			expect(learningCatalogue.getEvent).to.have.been.calledOnceWith(courseId, moduleId, eventId)
 			expect(learningCatalogue.updateEvent).to.have.been.calledOnceWith(courseId, moduleId, eventId, {
 				id: 'event-id',
 				venue: {
@@ -828,7 +823,7 @@ describe('EventController', function() {
 						endTime: '12:30',
 					},
 				],
-				status: Event.Status.ACTIVE,
+				status: 'Active',
 				cancellationReason: 'The event is no longer available',
 			})
 			expect(response.redirect).to.have.been.calledOnceWith(`/content-management/courses/${courseId}/modules/${moduleId}/events/${eventId}/dateRanges`)
@@ -883,15 +878,14 @@ describe('EventController', function() {
 					availability: 5,
 				},
 				dateRanges: [],
-				status: Event.Status.ACTIVE,
+				status: 'Active',
 				cancellationReason: 'The event is no longer available',
 			}
-			learningCatalogue.getEvent = sinon.stub().returns(event)
+
+			response.locals.event = event
 			learningCatalogue.updateEvent = sinon.stub().returns(Promise.reject(error))
 
 			await eventController.updateDateRange()(request, response, next)
-
-			expect(learningCatalogue.getEvent).to.have.been.calledOnceWith(courseId, moduleId, eventId)
 			expect(learningCatalogue.updateEvent).to.have.been.calledOnceWith(courseId, moduleId, eventId, {
 				id: 'event-id',
 				venue: {
@@ -908,7 +902,7 @@ describe('EventController', function() {
 						endTime: '12:30',
 					},
 				],
-				status: Event.Status.ACTIVE,
+				status: 'Active',
 				cancellationReason: 'The event is no longer available',
 			})
 			expect(next).to.have.been.calledOnceWith(error)
@@ -950,12 +944,12 @@ describe('EventController', function() {
 
 			dateRangeCommandValidator.check = sinon.stub().returns(errors)
 
-			learningCatalogue.getEvent = sinon.stub()
+			learningCatalogue.getCourse = sinon.stub()
 			learningCatalogue.updateEvent = sinon.stub().returns(Promise.resolve())
 
 			await eventController.updateDateRange()(request, response, next)
 
-			expect(learningCatalogue.getEvent).to.have.not.been.called
+			expect(learningCatalogue.getCourse).to.have.not.been.called
 			expect(learningCatalogue.updateEvent).to.not.have.been.called
 			expect(response.render).to.have.been.calledOnceWith('page/course/module/events/event-dateRange-edit', {
 				errors: errors,
@@ -1012,12 +1006,12 @@ describe('EventController', function() {
 			dateRangeCommand.asDateRange = sinon.stub().returns(dateRange)
 			dateRangeValidator.check = sinon.stub().returns(errors)
 
-			learningCatalogue.getEvent = sinon.stub()
+			learningCatalogue.getCourse = sinon.stub()
 			learningCatalogue.updateEvent = sinon.stub().returns(Promise.resolve())
 
 			await eventController.updateDateRange()(request, response, next)
 
-			expect(learningCatalogue.getEvent).to.have.not.been.called
+			expect(learningCatalogue.getCourse).to.have.not.been.called
 			expect(learningCatalogue.updateEvent).to.not.have.been.called
 			expect(dateRangeCommandValidator.check).to.have.been.calledOnceWith(request.body)
 			expect(dateRangeCommandFactory.create).to.have.been.calledOnceWith(request.body)
@@ -1104,12 +1098,12 @@ describe('EventController', function() {
 					},
 				],
 			}
-			learningCatalogue.getEvent = sinon.stub().returns(event)
+
+			response.locals.event = event
 			learningCatalogue.updateEvent = sinon.stub().returns(Promise.resolve(event))
 
 			await eventController.addDateRange()(request, response, next)
 
-			expect(learningCatalogue.getEvent).to.have.been.calledOnceWith(courseId, moduleId, eventId)
 			expect(learningCatalogue.updateEvent).to.have.been.calledOnceWith(courseId, moduleId, eventId, {
 				id: 'event-id',
 				venue: {
@@ -1173,7 +1167,7 @@ describe('EventController', function() {
 
 			dateRangeValidator.check = sinon.stub().returns(errors)
 
-			const event = <Event>{
+			response.locals.event = <Event>{
 				id: 'event-id',
 				venue: {
 					address: 'London',
@@ -1189,12 +1183,11 @@ describe('EventController', function() {
 					},
 				],
 			}
-			learningCatalogue.getEvent = sinon.stub().returns(event)
+
 			learningCatalogue.updateEvent = sinon.stub().returns(Promise.reject(error))
 
 			await eventController.addDateRange()(request, response, next)
 
-			expect(learningCatalogue.getEvent).to.have.been.calledOnceWith(courseId, moduleId, eventId)
 			expect(learningCatalogue.updateEvent).to.have.been.calledOnceWith(courseId, moduleId, eventId, {
 				id: 'event-id',
 				venue: {
@@ -1253,12 +1246,12 @@ describe('EventController', function() {
 
 			dateRangeCommandValidator.check = sinon.stub().returns(errors)
 
-			learningCatalogue.getEvent = sinon.stub()
+			learningCatalogue.getCourse = sinon.stub()
 			learningCatalogue.updateEvent = sinon.stub().returns(Promise.resolve())
 
 			await eventController.addDateRange()(request, response, next)
 
-			expect(learningCatalogue.getEvent).to.have.not.been.called
+			expect(learningCatalogue.getCourse).to.have.not.been.called
 			expect(learningCatalogue.updateEvent).to.not.have.been.called
 			expect(response.render).to.have.been.calledOnceWith('page/course/module/events/event-dateRange-edit', {
 				courseId: courseId,
@@ -1314,13 +1307,13 @@ describe('EventController', function() {
 			dateRangeCommand.asDateRange = sinon.stub().returns(dateRange)
 			dateRangeValidator.check = sinon.stub().returns(errors)
 
-			learningCatalogue.getEvent = sinon.stub()
+			learningCatalogue.getCourse = sinon.stub()
 
 			learningCatalogue.updateEvent = sinon.stub().returns(Promise.resolve())
 
 			await eventController.addDateRange()(request, response, next)
 
-			expect(learningCatalogue.getEvent).to.have.not.been.called
+			expect(learningCatalogue.getCourse).to.have.not.been.called
 			expect(learningCatalogue.updateEvent).to.not.have.been.called
 			expect(dateRangeCommandValidator.check).to.have.been.calledOnceWith(request.body)
 			expect(dateRangeCommandFactory.create).to.have.been.calledOnceWith(request.body)

--- a/test/unit/learning-catalogue/indexTest.ts
+++ b/test/unit/learning-catalogue/indexTest.ts
@@ -115,7 +115,7 @@ describe('Learning Catalogue tests', () => {
 			courseService.get = sinon.stub()
 
 			await learningCatalogue.getCourse(courseId)
-			return expect(courseService.get).to.have.been.calledOnceWith(`/courses/${courseId}`)
+			return expect(courseService.get).to.have.been.calledOnceWith(`/courses/${courseId}?includeAvailability=false`)
 		})
 	})
 
@@ -173,18 +173,6 @@ describe('Learning Catalogue tests', () => {
 			await learningCatalogue.createEvent(courseId, moduleId, event)
 
 			return expect(eventService.create).to.have.been.calledOnceWith(`/courses/${courseId}/modules/${moduleId}/events`, event)
-		})
-
-		it('should call eventService when getting an event', async () => {
-			const courseId: string = 'course-id'
-			const moduleId: string = 'module-id'
-			const eventId: string = 'event-id'
-
-			eventService.get = sinon.stub()
-
-			await learningCatalogue.getEvent(courseId, moduleId, eventId)
-
-			return expect(eventService.get).to.have.been.calledOnceWith(`/courses/${courseId}/modules/${moduleId}/events/${eventId}`)
 		})
 
 		it('should call eventService when updating an event', async () => {

--- a/test/unit/learning-catalogue/model/factory/moduleFactoryTest.ts
+++ b/test/unit/learning-catalogue/model/factory/moduleFactoryTest.ts
@@ -4,7 +4,6 @@ import {expect} from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 import {ModuleFactory} from '../../../../../src/learning-catalogue/model/factory/moduleFactory'
 import {EventFactory} from '../../../../../src/learning-catalogue/model/factory/eventFactory'
-import {Event} from '../../../../../src/learning-catalogue/model/event'
 
 chai.use(chaiAsPromised)
 
@@ -72,7 +71,7 @@ describe('ModuleFactory tests', () => {
 						availability: 99,
 					},
 					dateRanges: [{date: '2019-01-01', startTime: '09:00:00', endTime: '17:00:00'}],
-					status: Event.Status.ACTIVE,
+					status: 'Active',
 				},
 			])
 


### PR DESCRIPTION
- When an event is cancelled, handle it via csl-service
- Prefer Elasticsearch event data when displaying event status
- Refactor event logic to better make use of existing API calls