### PR TITLE
LC-3669: Delete draft courses

### DIFF
--- a/src/controllers/courseController.ts
+++ b/src/controllers/courseController.ts
@@ -52,6 +52,10 @@ export class CourseController implements FormController {
 		this.router.post('/content-management/courses/title/', xss(), this.createCourseTitle())
 		this.router.post('/content-management/courses/title/:courseId', xss(), this.updateCourseTitle())
 
+		this.router.get('/content-management/courses/delete/:courseId', xss(), this.renderDeleteCourseConfirmationPage())
+		this.router.post('/content-management/courses/delete/:courseId', xss(), this.deleteCourse())
+		this.router.get('/content-management/courses/deleted', xss(), this.renderCourseDeletedPage())
+
 		this.router.get('/content-management/courses/details/:courseId?', xss(), this.getCourseDetails())
 		this.router.post('/content-management/courses/details/', xss(), this.createCourseDetails())
 		this.router.post('/content-management/courses/details/:courseId', xss(), this.updateCourseDetails())
@@ -108,7 +112,8 @@ export class CourseController implements FormController {
 				eventIdToModuleId,
 				grades,
 				sortedAudiences,
-				courseUrl
+				courseUrl,
+				showDeleteCourseLink: res.locals.course.hasBeenPublished !== undefined && res.locals.course.status === "Draft" && res.locals.course.hasBeenPublished === false
 			})
 		}
 	}
@@ -278,6 +283,55 @@ export class CourseController implements FormController {
 		}
 	}
 
+	renderDeleteCourseConfirmationPage(){
+		return async (request: Request, response: Response, next: NextFunction) => {
+			const course = response.locals.course
+			if(course.hasBeenPublished === true){
+				response.redirect(`/content-management`)
+			}
+			else{
+				response.render('page/course/delete-course-confirmation')
+			}
+			
+		}
+	}
+
+	deleteCourse() {
+		return async (request: Request, response: Response, next: NextFunction) => {
+			const courseId = request.params.courseId
+
+			request.session!.deletedCourseTitle = response.locals.course.title
+			await this.learningCatalogue
+					.deleteCourse(courseId)
+					.then(() => {
+						response.redirect(`/content-management/courses/deleted`)
+					})
+					.catch(error => {
+						next(error)
+					})
+			
+		}
+	}
+
+	renderCourseDeletedPage() {
+		return async (request: Request, response: Response, next: NextFunction) => {
+			const courseTitle = request.session!.deletedCourseTitle
+			delete request.session!.deletedCourseTitle
+
+			if(courseTitle === undefined){
+				response.redirect('/content-management')
+			}
+			else{
+				
+				response.render('page/course/course-deleted', {
+					courseTitle
+				})
+			}
+			
+			
+		}
+	}
+
 	sortModules() {
 		return async (request: Request, response: Response, next: NextFunction) => {
 			return await this.courseService
@@ -300,6 +354,7 @@ export class CourseController implements FormController {
 	publishCourse() {
 		return async (request: Request, response: Response, next: NextFunction) => {
 			let course = response.locals.course
+			course.hasBeenPublished = true
 
 			await this.learningCatalogue
 				.publishCourse(course)

--- a/src/controllers/courseController.ts
+++ b/src/controllers/courseController.ts
@@ -113,7 +113,10 @@ export class CourseController implements FormController {
 				grades,
 				sortedAudiences,
 				courseUrl,
-				showDeleteCourseLink: res.locals.course.hasBeenPublished !== undefined && res.locals.course.status === "Draft" && res.locals.course.hasBeenPublished === false
+				showDeleteCourseLink: res.locals.course.hasBeenPublished !== undefined 
+					&& res.locals.course.status === "Draft" 
+					&& res.locals.course.hasBeenPublished === false
+					&& req.user?.hasLearningDelete()
 			})
 		}
 	}

--- a/src/learning-catalogue/index.ts
+++ b/src/learning-catalogue/index.ts
@@ -148,6 +148,23 @@ export class LearningCatalogue {
 		}
 	}
 
+	async deleteCourse(courseId: string): Promise<void> {
+		try{
+			await this._courseService.delete(`/courses/${courseId}`)
+			let typeahead = await this.courseTypeaheadCache.getTypeahead()
+			if (typeahead !== undefined) {
+				typeahead.removeCourse(courseId)
+				await this.courseTypeaheadCache.setTypeahead(typeahead)
+			}
+		}
+		catch (e) {
+			if (e instanceof HttpException && e.statusCode === 407) {
+				return
+			}
+			throw e
+		}
+	}
+
 	async getRequiredLearning(departmentCodes: string[]): Promise<DefaultPageResults<Course>> {
 		return await this._courseService.listAllWithPagination(`/courses?mandatory=true&department=${departmentCodes}`)
 	}

--- a/src/learning-catalogue/model/course.ts
+++ b/src/learning-catalogue/model/course.ts
@@ -60,6 +60,8 @@ export class Course {
 
 	topicId: string
 
+	hasBeenPublished: boolean
+
 	getCost() {
 		return this.modules.map(module => module.cost).reduce((acc: number, moduleCost) => acc + (moduleCost || 0), 0)
 	}

--- a/src/learning-catalogue/model/factory/courseFactory.ts
+++ b/src/learning-catalogue/model/factory/courseFactory.ts
@@ -30,6 +30,7 @@ export class CourseFactory {
 		course.learningProvider = plainToInstance(LearningProvider, data.learningProvider)
 		course.visibility = Visibility[data.visibility as keyof typeof Visibility]
 		course.topicId = data.topicId
+		course.hasBeenPublished = data.hasBeenPublished
 
 		if (course.modules) {
 			let duration = 0

--- a/views/assets/styles/component/highlight.scss
+++ b/views/assets/styles/component/highlight.scss
@@ -1,0 +1,10 @@
+.govuk-box-highlight {
+	background-color: #005ea5;
+	padding: 1em;
+	
+	h1, p {
+		color: white;
+		font-weight: 700;
+		text-align: center;
+	}
+}

--- a/views/assets/styles/main.scss
+++ b/views/assets/styles/main.scss
@@ -5,4 +5,5 @@
 @import 'banner';
 @import 'page/pages';
 @import 'component/components';
-@import 'footer'
+@import 'footer';
+@import 'component/highlight';

--- a/views/page/course/course-deleted.html
+++ b/views/page/course/course-deleted.html
@@ -1,0 +1,24 @@
+{% from "button/macro.njk" import govukButton %}
+
+{% extends "../../component/Page.njk" %}
+
+{% block pageTitle %}{{ "Course deleted" }} - {{ i18n.proposition_name }}{% endblock %}
+
+{% set banner = true %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-body govuk-box-highlight">
+                <h1>{{ courseTitle }}</h1>
+                <p>This course has been successfully deleted</p>
+            </div>
+        </div>
+    </div>
+
+    <p class="govuk-body">
+        Do you want to choose another course? <a class="button" href="/content-management" aria-label="Find another course">Find a course</a>
+    </p>
+
+{% endblock %}

--- a/views/page/course/course-overview.html
+++ b/views/page/course/course-overview.html
@@ -76,6 +76,13 @@
                                 text: 'Preview and edit'
                             }
                         ] %}
+                        {% if showDeleteCourseLink %}
+                            {% set action = actions.push({
+                                    link: '/content-management/courses/delete/' + course.id,
+                                    text: 'Delete this course'
+                            }) %}
+                        {% endif %}
+
                         {{ menu("Actions", actions) }}
 
                         {% set linkActions = [

--- a/views/page/course/delete-course-confirmation.html
+++ b/views/page/course/delete-course-confirmation.html
@@ -1,0 +1,34 @@
+{% from "button/macro.njk" import govukButton %}
+
+{% extends "../../component/Page.njk" %}
+
+{% block pageTitle %}{{ "Confirm course deletion" }} - {{ i18n.proposition_name }}{% endblock %}
+
+{% set banner = true %}
+{% set backButton = "/content-management/courses/" + course.id + "/overview" %}
+
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h1 class="govuk-heading-m govuk-!-font-size-36">Confirm deletion of course '{{ course.title }}'</h1>
+
+            <p class="govuk-body">Are you sure you want to delete course '{{ course.title }}'?</p>
+            <p class="govuk-body">By deleting this course, it will not be discoverable in the main course catalogue and will not appear in search results for all relevant users.</p>
+            <p class="govuk-body">Learners will not be able to discover or book this course.</p>
+            <p class="govuk-body">Deleting this course is irreversible.</p>
+
+            <form action="/content-management/courses/delete/{{course.id}}" method="post">
+                <input type="hidden" name="_csrf" value="{{ _csrf }}" />
+                <div class="button-container">
+                    {{ govukButton({
+                        text: "Delete course",
+                        "classes": "govuk-button--delete"
+                    }) }}
+                </div>
+            </form>
+        </div>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
This change creates the workflow to delete a Draft course. It creates 2 new pages (confirm deletion, course deleted) and some updates to existing endpoints to include the `hasBeenPublished` flag.