### PR TITLE
LC-3789: Optimise caches

### DIFF
--- a/src/applicationContext.ts
+++ b/src/applicationContext.ts
@@ -301,10 +301,7 @@ export class ApplicationContext {
 			this.audienceFactory,
 			this.courseService,
 			this.csrsService,
-			this.audienceService,
-			this.requiredLearningCache,
-			this.learningPlanCache,
-			this.learningRecordCache
+			this.audienceService
 		)
 		this.organisationalUnitPageModelFactory = new OrganisationalUnitPageModelFactory()
 		this.organisationalUnitPageModelValidator = new Validator<OrganisationalUnitPageModel>(this.organisationalUnitPageModelFactory)

--- a/src/applicationContext.ts
+++ b/src/applicationContext.ts
@@ -69,6 +69,7 @@ import {ProfileCache} from './csrs/profileCache'
 import { CslService } from './csl-service/service/cslService'
 import { FormattedOrganisationListCache } from './csrs/formattedOrganisationListCache'
 import {LearningPlanCache} from './csl-service/learningPlanCache'
+import { RequiredLearningCache } from './csl-service/requiredLearningCache'
 
 export class ApplicationContext {
 
@@ -141,6 +142,7 @@ export class ApplicationContext {
 	civilServantProfileService: CivilServantProfileService
 	cslService: CslService
 	formattedOrganisationListCache: FormattedOrganisationListCache
+	requiredLearningCache: RequiredLearningCache
 
 	public lpgUiUrl: string = config.FRONTEND.LPG_UI_URL
 
@@ -186,6 +188,8 @@ export class ApplicationContext {
 
 		this.formattedOrganisationListCache = new FormattedOrganisationListCache(redisClient, config.ORG_REDIS.ttl_seconds)
 		this.cslService = new CslService(this.formattedOrganisationListCache, this.cslServiceClient)
+
+		this.requiredLearningCache = new RequiredLearningCache(redisClient, config.ORG_REDIS.ttl_seconds)
 
 		this.learningCatalogueConfig = createConfig(config.COURSE_CATALOGUE)
 
@@ -291,7 +295,8 @@ export class ApplicationContext {
 			this.audienceFactory,
 			this.courseService,
 			this.csrsService,
-			this.audienceService
+			this.audienceService,
+			this.requiredLearningCache
 		)
 		this.organisationalUnitPageModelFactory = new OrganisationalUnitPageModelFactory()
 		this.organisationalUnitPageModelValidator = new Validator<OrganisationalUnitPageModel>(this.organisationalUnitPageModelFactory)

--- a/src/applicationContext.ts
+++ b/src/applicationContext.ts
@@ -70,6 +70,7 @@ import { CslService } from './csl-service/service/cslService'
 import { FormattedOrganisationListCache } from './csrs/formattedOrganisationListCache'
 import {LearningPlanCache} from './csl-service/learningPlanCache'
 import { RequiredLearningCache } from './csl-service/requiredLearningCache'
+import {LearningRecordCache} from './csl-service/learningRecordCache'
 
 export class ApplicationContext {
 
@@ -143,6 +144,7 @@ export class ApplicationContext {
 	cslService: CslService
 	formattedOrganisationListCache: FormattedOrganisationListCache
 	requiredLearningCache: RequiredLearningCache
+	learningRecordCache: LearningRecordCache
 
 	public lpgUiUrl: string = config.FRONTEND.LPG_UI_URL
 
@@ -190,6 +192,7 @@ export class ApplicationContext {
 		this.cslService = new CslService(this.formattedOrganisationListCache, this.cslServiceClient)
 
 		this.requiredLearningCache = new RequiredLearningCache(redisClient, config.ORG_REDIS.ttl_seconds)
+		this.learningRecordCache = new LearningRecordCache(redisClient, config.ORG_REDIS.ttl_seconds)
 
 		this.learningCatalogueConfig = createConfig(config.COURSE_CATALOGUE)
 
@@ -296,7 +299,9 @@ export class ApplicationContext {
 			this.courseService,
 			this.csrsService,
 			this.audienceService,
-			this.requiredLearningCache
+			this.requiredLearningCache,
+			this.learningPlanCache,
+			this.learningRecordCache
 		)
 		this.organisationalUnitPageModelFactory = new OrganisationalUnitPageModelFactory()
 		this.organisationalUnitPageModelValidator = new Validator<OrganisationalUnitPageModel>(this.organisationalUnitPageModelFactory)

--- a/src/applicationContext.ts
+++ b/src/applicationContext.ts
@@ -71,6 +71,7 @@ import { FormattedOrganisationListCache } from './csrs/formattedOrganisationList
 import {LearningPlanCache} from './csl-service/learningPlanCache'
 import { RequiredLearningCache } from './csl-service/requiredLearningCache'
 import {LearningRecordCache} from './csl-service/learningRecordCache'
+import { LearningCacheManager } from './lib/learningCacheManager'
 
 export class ApplicationContext {
 
@@ -145,6 +146,7 @@ export class ApplicationContext {
 	formattedOrganisationListCache: FormattedOrganisationListCache
 	requiredLearningCache: RequiredLearningCache
 	learningRecordCache: LearningRecordCache
+	learningCacheManager: LearningCacheManager
 
 	public lpgUiUrl: string = config.FRONTEND.LPG_UI_URL
 
@@ -197,7 +199,8 @@ export class ApplicationContext {
 		this.learningCatalogueConfig = createConfig(config.COURSE_CATALOGUE)
 
 		this.courseTypeaheadCache = new CourseTypeAheadCache(redisClient, config.ORG_REDIS.ttl_seconds)
-		this.learningCatalogue = new LearningCatalogue(this.learningCatalogueConfig, this.auth, this.cslServiceClient, this.courseTypeaheadCache)
+		this.learningCacheManager = new LearningCacheManager(this.requiredLearningCache, this.learningPlanCache, this.learningRecordCache)
+		this.learningCatalogue = new LearningCatalogue(this.learningCatalogueConfig, this.auth, this.cslServiceClient, this.courseTypeaheadCache, this.learningCacheManager)
 
 		this.courseFactory = new CourseFactory()
 

--- a/src/controllers/audience/audienceController.ts
+++ b/src/controllers/audience/audienceController.ts
@@ -12,6 +12,8 @@ import {OrganisationalUnit} from '../../csrs/model/organisationalUnit'
 import { OrganisationalUnitTypeAhead } from '../../csrs/model/organisationalUnitTypeAhead'
 import {applyLearningCatalogueMiddleware} from '../middleware/learningCatalogueMiddleware'
 import { RequiredLearningCache } from 'src/csl-service/requiredLearningCache'
+import { LearningPlanCache } from 'src/csl-service/learningPlanCache'
+import { LearningRecordCache } from 'src/csl-service/learningRecordCache'
 const { xss } = require('express-xss-sanitizer')
 
 
@@ -24,6 +26,8 @@ export class AudienceController {
 	audienceService: AudienceService
 	router: Router
 	requiredLearningCache: RequiredLearningCache
+	learningPlanCache: LearningPlanCache
+	learningRecordCache: LearningRecordCache
 
 	constructor(
 		learningCatalogue: LearningCatalogue,
@@ -32,7 +36,9 @@ export class AudienceController {
 		courseService: CourseService,
 		csrsService: CsrsService,
 		audienceService: AudienceService,
-		requiredLearningCache: RequiredLearningCache
+		requiredLearningCache: RequiredLearningCache,
+		learningPlanCache: LearningPlanCache,
+		learningRecordCache: LearningRecordCache
 	) {
 		this.learningCatalogue = learningCatalogue
 		this.audienceValidator = audienceValidator
@@ -44,6 +50,8 @@ export class AudienceController {
 		this.configurePathParametersProcessing()
 		this.setRouterPaths()
 		this.requiredLearningCache = requiredLearningCache
+		this.learningPlanCache = learningPlanCache
+		this.learningRecordCache = learningRecordCache
 	}
 
 	private configurePathParametersProcessing() {
@@ -344,10 +352,8 @@ export class AudienceController {
 			await this.learningCatalogue
 				.updateAudience(res.locals.course.id, res.locals.audience)
 				.then(() => {
-					this.requiredLearningCache.deleteAllIds()
-					.then(() => {
-						res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)
-					})					
+					this.clearCache()
+					res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)					
 				})
 				.catch(error => next(error))
 		}
@@ -379,12 +385,16 @@ export class AudienceController {
 			await this.learningCatalogue
 				.updateAudience(res.locals.course.id, res.locals.audience)
 				.then(() => {
-					this.requiredLearningCache.deleteAllIds()
-					.then(() => {
-						res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)
-					})
+					this.clearCache()
+					res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)					
 				})
 				.catch(error => next(error))
 		}
+	}
+
+	clearCache(){
+		this.requiredLearningCache.deleteAllIds()
+		this.learningPlanCache.deleteAllIds()
+		this.learningRecordCache.deleteAllIds()
 	}
 }

--- a/src/controllers/audience/audienceController.ts
+++ b/src/controllers/audience/audienceController.ts
@@ -11,6 +11,7 @@ import * as moment from 'moment'
 import {OrganisationalUnit} from '../../csrs/model/organisationalUnit'
 import { OrganisationalUnitTypeAhead } from '../../csrs/model/organisationalUnitTypeAhead'
 import {applyLearningCatalogueMiddleware} from '../middleware/learningCatalogueMiddleware'
+import { RequiredLearningCache } from 'src/csl-service/requiredLearningCache'
 const { xss } = require('express-xss-sanitizer')
 
 
@@ -22,6 +23,7 @@ export class AudienceController {
 	csrsService: CsrsService
 	audienceService: AudienceService
 	router: Router
+	requiredLearningCache: RequiredLearningCache
 
 	constructor(
 		learningCatalogue: LearningCatalogue,
@@ -29,7 +31,8 @@ export class AudienceController {
 		audienceFactory: AudienceFactory,
 		courseService: CourseService,
 		csrsService: CsrsService,
-		audienceService: AudienceService
+		audienceService: AudienceService,
+		requiredLearningCache: RequiredLearningCache
 	) {
 		this.learningCatalogue = learningCatalogue
 		this.audienceValidator = audienceValidator
@@ -40,6 +43,7 @@ export class AudienceController {
 		this.audienceService = audienceService
 		this.configurePathParametersProcessing()
 		this.setRouterPaths()
+		this.requiredLearningCache = requiredLearningCache
 	}
 
 	private configurePathParametersProcessing() {
@@ -339,7 +343,8 @@ export class AudienceController {
 
 			await this.learningCatalogue
 				.updateAudience(res.locals.course.id, res.locals.audience)
-				.then(() => {
+				.then(async () => {
+					await this.clearRequiredLearningCaches()
 					res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)
 				})
 				.catch(error => next(error))
@@ -371,10 +376,16 @@ export class AudienceController {
 
 			await this.learningCatalogue
 				.updateAudience(res.locals.course.id, res.locals.audience)
-				.then(() => {
+				.then(async () => {
+					await this.clearRequiredLearningCaches()
 					res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)
 				})
 				.catch(error => next(error))
 		}
+	}
+
+	private async clearRequiredLearningCaches(){
+		const cachedRequiredLearningIds: string[] = await this.requiredLearningCache.getAllIds()
+		await this.requiredLearningCache.deleteMultiple(cachedRequiredLearningIds)
 	}
 }

--- a/src/controllers/audience/audienceController.ts
+++ b/src/controllers/audience/audienceController.ts
@@ -343,9 +343,11 @@ export class AudienceController {
 
 			await this.learningCatalogue
 				.updateAudience(res.locals.course.id, res.locals.audience)
-				.then(async () => {
-					await this.clearRequiredLearningCaches()
-					res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)
+				.then(() => {
+					this.requiredLearningCache.deleteAllIds()
+					.then(() => {
+						res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)
+					})					
 				})
 				.catch(error => next(error))
 		}
@@ -376,16 +378,13 @@ export class AudienceController {
 
 			await this.learningCatalogue
 				.updateAudience(res.locals.course.id, res.locals.audience)
-				.then(async () => {
-					await this.clearRequiredLearningCaches()
-					res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)
+				.then(() => {
+					this.requiredLearningCache.deleteAllIds()
+					.then(() => {
+						res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)
+					})
 				})
 				.catch(error => next(error))
 		}
-	}
-
-	private async clearRequiredLearningCaches(){
-		const cachedRequiredLearningIds: string[] = await this.requiredLearningCache.getAllIds()
-		await this.requiredLearningCache.deleteMultiple(cachedRequiredLearningIds)
 	}
 }

--- a/src/controllers/audience/audienceController.ts
+++ b/src/controllers/audience/audienceController.ts
@@ -11,9 +11,6 @@ import * as moment from 'moment'
 import {OrganisationalUnit} from '../../csrs/model/organisationalUnit'
 import { OrganisationalUnitTypeAhead } from '../../csrs/model/organisationalUnitTypeAhead'
 import {applyLearningCatalogueMiddleware} from '../middleware/learningCatalogueMiddleware'
-import { RequiredLearningCache } from 'src/csl-service/requiredLearningCache'
-import { LearningPlanCache } from 'src/csl-service/learningPlanCache'
-import { LearningRecordCache } from 'src/csl-service/learningRecordCache'
 const { xss } = require('express-xss-sanitizer')
 
 
@@ -25,9 +22,6 @@ export class AudienceController {
 	csrsService: CsrsService
 	audienceService: AudienceService
 	router: Router
-	requiredLearningCache: RequiredLearningCache
-	learningPlanCache: LearningPlanCache
-	learningRecordCache: LearningRecordCache
 
 	constructor(
 		learningCatalogue: LearningCatalogue,
@@ -35,10 +29,7 @@ export class AudienceController {
 		audienceFactory: AudienceFactory,
 		courseService: CourseService,
 		csrsService: CsrsService,
-		audienceService: AudienceService,
-		requiredLearningCache: RequiredLearningCache,
-		learningPlanCache: LearningPlanCache,
-		learningRecordCache: LearningRecordCache
+		audienceService: AudienceService
 	) {
 		this.learningCatalogue = learningCatalogue
 		this.audienceValidator = audienceValidator
@@ -49,9 +40,6 @@ export class AudienceController {
 		this.audienceService = audienceService
 		this.configurePathParametersProcessing()
 		this.setRouterPaths()
-		this.requiredLearningCache = requiredLearningCache
-		this.learningPlanCache = learningPlanCache
-		this.learningRecordCache = learningRecordCache
 	}
 
 	private configurePathParametersProcessing() {

--- a/src/controllers/audience/audienceController.ts
+++ b/src/controllers/audience/audienceController.ts
@@ -350,9 +350,8 @@ export class AudienceController {
 			res.locals.audience.frequency = undefined
 
 			await this.learningCatalogue
-				.updateAudience(res.locals.course.id, res.locals.audience)
+				.updateAudience(res.locals.course.id, res.locals.audience, {clearLearningCache: true})
 				.then(() => {
-					this.clearCache()
 					res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)					
 				})
 				.catch(error => next(error))
@@ -383,18 +382,11 @@ export class AudienceController {
 			}
 
 			await this.learningCatalogue
-				.updateAudience(res.locals.course.id, res.locals.audience)
+				.updateAudience(res.locals.course.id, res.locals.audience, {clearLearningCache: true})
 				.then(() => {
-					this.clearCache()
 					res.redirect(`/content-management/courses/${req.params.courseId}/audiences/${req.params.audienceId}/configure`)					
 				})
 				.catch(error => next(error))
 		}
-	}
-
-	clearCache(){
-		this.requiredLearningCache.deleteAllIds()
-		this.learningPlanCache.deleteAllIds()
-		this.learningRecordCache.deleteAllIds()
 	}
 }

--- a/src/csl-service/learningRecordCache.ts
+++ b/src/csl-service/learningRecordCache.ts
@@ -1,0 +1,12 @@
+import {plainToClass} from 'class-transformer'
+import {CacheableObjectCache} from '../lib/cacheableObjectCache'
+
+export class LearningRecordCache extends CacheableObjectCache<any> {
+    getBaseKey(): string {
+        return 'learningRecord'
+    }
+
+    protected convert(cacheHit: string): {} {
+        return plainToClass(Object, cacheHit)
+    }
+}

--- a/src/csl-service/requiredLearningCache.ts
+++ b/src/csl-service/requiredLearningCache.ts
@@ -1,0 +1,12 @@
+import {plainToClass} from 'class-transformer'
+import {CacheableObjectCache} from '../lib/cacheableObjectCache'
+
+export class RequiredLearningCache extends CacheableObjectCache<any> {
+    getBaseKey(): string {
+        return 'requiredLearning'
+    }
+
+    protected convert(cacheHit: string): {} {
+        return plainToClass(Object, cacheHit)
+    }
+}

--- a/src/learning-catalogue/index.ts
+++ b/src/learning-catalogue/index.ts
@@ -16,6 +16,7 @@ import {BasicCourse, CourseTypeAhead} from './courseTypeAhead'
 import {RestServiceConfig} from '../lib/http/restServiceConfig'
 import {HttpException} from '../lib/exception/HttpException'
 import {Status} from './model/status'
+import { LearningCacheManager } from 'lib/learningCacheManager'
 
 export class LearningCatalogue {
 	private _eventService: EntityService<Event>
@@ -25,9 +26,10 @@ export class LearningCatalogue {
 	private _restService: OauthRestService
 	private _cslService: CslServiceClient
 	private courseTypeaheadCache: CourseTypeAheadCache
+	private learningCacheManager: LearningCacheManager
 
 	constructor(config: RestServiceConfig, auth: Auth, cslService: CslServiceClient,
-				courseTypeaheadCache: CourseTypeAheadCache) {
+				courseTypeaheadCache: CourseTypeAheadCache, learningCacheManager: LearningCacheManager) {
 		this._restService = new OauthRestService(config, auth)
 
 		this._eventService = new EntityService<Event>(this._restService, new EventFactory())
@@ -41,6 +43,7 @@ export class LearningCatalogue {
 		this._cslService = cslService
 
 		this.courseTypeaheadCache = courseTypeaheadCache
+		this.learningCacheManager = learningCacheManager
 	}
 
 	async listPublishedCourses(page: number = 0, size: number = 10): Promise<DefaultPageResults<Course>> {
@@ -215,10 +218,12 @@ export class LearningCatalogue {
 		return this._audienceService.get(`/courses/${courseId}/audiences/${audienceId}`)
 	}
 
-	async updateAudience(courseId: string, audience: Audience): Promise<Audience> {
+	async updateAudience(courseId: string, audience: Audience, options: UpdateAudienceOptions = {clearLearningCache: false}): Promise<Audience> {
 		const updatedAudience = await this._audienceService.update(`/courses/${courseId}/audiences/${audience.id}`, audience)
 		await this._cslService.clearCourseCache(courseId)
-
+		if(options.clearLearningCache) {
+			this.learningCacheManager.clearLearningCache()
+		}
 		return updatedAudience
 	}
 
@@ -244,4 +249,8 @@ export class LearningCatalogue {
 		this._audienceService = value
 	}
 
+}
+
+interface UpdateAudienceOptions {
+	clearLearningCache?: boolean
 }

--- a/src/learning-catalogue/index.ts
+++ b/src/learning-catalogue/index.ts
@@ -216,13 +216,16 @@ export class LearningCatalogue {
 	}
 
 	async updateAudience(courseId: string, audience: Audience): Promise<Audience> {
+		const updatedAudience = await this._audienceService.update(`/courses/${courseId}/audiences/${audience.id}`, audience)
 		await this._cslService.clearCourseCache(courseId)
-		return this._audienceService.update(`/courses/${courseId}/audiences/${audience.id}`, audience)
+
+		return updatedAudience
 	}
 
 	async deleteAudience(courseId: string, audienceId: string) {
+		const deletedAudience = await this._audienceService.delete(`/courses/${courseId}/audiences/${audienceId}`)
 		await this._cslService.clearCourseCache(courseId)
-		return this._audienceService.delete(`/courses/${courseId}/audiences/${audienceId}`)
+		return deletedAudience
 	}
 
 	set courseService(value: EntityService<Course>) {

--- a/src/lib/learningCacheManager.ts
+++ b/src/lib/learningCacheManager.ts
@@ -1,0 +1,23 @@
+import { RequiredLearningCache } from 'src/csl-service/requiredLearningCache'
+import { LearningPlanCache } from 'src/csl-service/learningPlanCache'
+import { LearningRecordCache } from 'src/csl-service/learningRecordCache'
+
+export class LearningCacheManager {
+    private requiredLearningCache: RequiredLearningCache
+    private learningPlanCache: LearningPlanCache
+    private learningRecordCache: LearningRecordCache
+
+    constructor(requiredLearningCache: RequiredLearningCache,
+                learningPlanCache: LearningPlanCache,
+                learningRecordCache: LearningRecordCache) {
+        this.requiredLearningCache = requiredLearningCache
+        this.learningPlanCache = learningPlanCache
+        this.learningRecordCache = learningRecordCache
+    }
+
+    clearLearningCache(){
+        this.requiredLearningCache.deleteAllIds()
+		this.learningPlanCache.deleteAllIds()
+		this.learningRecordCache.deleteAllIds()
+    }
+}

--- a/src/lib/redisCache.ts
+++ b/src/lib/redisCache.ts
@@ -53,6 +53,11 @@ export abstract class Cache<T> {
 		}
 	}
 
+	async deleteAllIds(){
+		const ids = await this.getAllIds()
+		await this.deleteMultiple(ids)
+	}
+
 	async deleteMultiple(ids: string[]){		
 		const pipeline: Multi = this.redisClient.multi()
 

--- a/src/lib/redisCache.ts
+++ b/src/lib/redisCache.ts
@@ -61,10 +61,8 @@ export abstract class Cache<T> {
 	async deleteMultiple(ids: string[]){		
 		const pipeline: Multi = this.redisClient.multi()
 
-		ids.forEach(async (id) => {			
-			const formattedKey = this.getFormattedKey(id)
-			await promisify(pipeline.expire).bind(pipeline)(formattedKey, 0)
-		})
+		const pipelineExpirePromises = ids.map(id => promisify(pipeline.expire).bind(pipeline)(this.getFormattedKey(id), 0))
+		Promise.all(pipelineExpirePromises)
 
 		await promisify(pipeline.exec).bind(pipeline)()		
 	}
@@ -74,12 +72,13 @@ export abstract class Cache<T> {
 		// redisClient.scan doesn't respect the configured keyPrefix
 		// so we need to add it to the MATCH pattern ourselves and then strip it from the results
 
-		const pattern: string = `${keyPrefix}${this.getBaseKey()}*`		
-		const scanResults = await promisify(this.redisClient.scan).bind(this.redisClient)(0, 'MATCH', pattern, 'COUNT', '1000000')
+		const keyWithPrefix: string = `${keyPrefix}${this.getBaseKey()}`
+
+		const scanResults = await promisify(this.redisClient.scan).bind(this.redisClient)(0, 'MATCH', `${keyWithPrefix}*`, 'COUNT', '1000000')
 		
 		const ids: string[] = scanResults[1]
-			.map((key: string) => key.replace(new RegExp(`^${keyPrefix}`),  ''))		
-			.map((key: string) => key.replace(`${this.getBaseKey()}:`,  ''))		
+			.map((key: string) => key.replace(new RegExp(`^${keyWithPrefix}:`),  ''))			
+		
 		return ids
 	}
 

--- a/src/lib/redisCache.ts
+++ b/src/lib/redisCache.ts
@@ -73,18 +73,33 @@ export abstract class Cache<T> {
 		// so we need to add it to the MATCH pattern ourselves and then strip it from the results
 
 		const keyWithPrefix: string = `${keyPrefix}${this.getBaseKey()}`
+		
+		const keys: string[] = await this.scanInBatches(`${keyWithPrefix}:*`, 1000)
 
-		const scanResults = await promisify(this.redisClient.scan).bind(this.redisClient)(0, 'MATCH', `${keyWithPrefix}*`, 'COUNT', '1000000')
-		
-		const ids: string[] = scanResults[1]
-			.map((key: string) => key.replace(new RegExp(`^${keyWithPrefix}:`),  ''))			
-		
+		const ids: string[] = keys
+			.map((key: string) => key.replace(new RegExp(`^${keyWithPrefix}:`),  ''))		
+
 		return ids
 	}
 
 	protected getFormattedKey(keyPart: string | number) {
 		return `${this.getBaseKey()}:${keyPart}`
 	}
+
+	protected async scanInBatches(pattern: string, batchSize: number){
+		const results = []
+		let cursor: string = '0'
+
+		do {
+			const [newCursor, resultsFromScan] = await await promisify(this.redisClient.scan).bind(this.redisClient)(0, 'MATCH', pattern, 'COUNT', batchSize)
+			cursor = newCursor
+			results.push(...resultsFromScan)
+		}
+		while (cursor != '0')
+		return results
+
+	}
+
 
 	protected abstract getBaseKey(): string
 	protected abstract convert(cacheHit: any): T

--- a/src/lib/redisCache.ts
+++ b/src/lib/redisCache.ts
@@ -1,8 +1,9 @@
 
-import { RedisClient } from 'redis'
+import { Multi, RedisClient } from 'redis'
 import { promisify } from 'util'
 import { Logger } from 'winston'
 import { getLogger } from '../utils/logger'
+import * as config from '../config/index'
 
 export abstract class Cache<T> {
 	protected logger: Logger
@@ -50,6 +51,31 @@ export abstract class Cache<T> {
 			this.logger.error(`Error deleting object from cache with key ${key}. Error: ${e}.`)
 			throw e
 		}
+	}
+
+	async deleteMultiple(ids: string[]){		
+		const pipeline: Multi = this.redisClient.multi()
+
+		ids.forEach(async (id) => {			
+			const formattedKey = this.getFormattedKey(id)
+			await promisify(pipeline.expire).bind(pipeline)(formattedKey, 0)
+		})
+
+		await promisify(pipeline.exec).bind(pipeline)()		
+	}
+
+	async getAllIds(): Promise<string[]> {
+		const keyPrefix: string = config.REDIS.keyPrefix
+		// redisClient.scan doesn't respect the configured keyPrefix
+		// so we need to add it to the MATCH pattern ourselves and then strip it from the results
+
+		const pattern: string = `${keyPrefix}${this.getBaseKey()}*`		
+		const scanResults = await promisify(this.redisClient.scan).bind(this.redisClient)(0, 'MATCH', pattern, 'COUNT', '1000000')
+		
+		const ids: string[] = scanResults[1]
+			.map((key: string) => key.replace(new RegExp(`^${keyPrefix}`),  ''))		
+			.map((key: string) => key.replace(`${this.getBaseKey()}:`,  ''))		
+		return ids
 	}
 
 	protected getFormattedKey(keyPart: string | number) {

--- a/test/unit/controllers/audience/audienceControllerTest.ts
+++ b/test/unit/controllers/audience/audienceControllerTest.ts
@@ -18,6 +18,8 @@ import {Course} from '../../../../src/learning-catalogue/model/course'
 import {AudienceService} from 'lib/audienceService'
 import { OrganisationalUnitTypeAhead } from '../../../../src/csrs/model/organisationalUnitTypeAhead'
 import {RequiredLearningCache} from '../../../../src/csl-service/requiredLearningCache'
+import { LearningPlanCache } from '../../../../src/csl-service/learningPlanCache'
+import { LearningRecordCache } from '../../../../src/csl-service/learningRecordCache'
 
 chai.use(sinonChai)
 
@@ -34,6 +36,8 @@ describe('AudienceController', () => {
 	let next: NextFunction
 	let error: Error
 	let requiredLearningCache: RequiredLearningCache
+	let learningPlanCache: LearningPlanCache
+	let learningRecordCache: LearningRecordCache
 
 	const courseId = 'course-id'
 	const audienceId = 'audience-id'
@@ -46,7 +50,9 @@ describe('AudienceController', () => {
 		audienceValidator = new Validator(audienceFactory)
 		audienceService = <AudienceService>{}
 		requiredLearningCache = <RequiredLearningCache>{}
-		audienceController = new AudienceController(learningCatalogue, audienceValidator, audienceFactory, courseService, csrsService, audienceService, requiredLearningCache)
+		learningPlanCache = <LearningPlanCache>{}
+		learningRecordCache = <LearningRecordCache>{}
+		audienceController = new AudienceController(learningCatalogue, audienceValidator, audienceFactory, courseService, csrsService, audienceService, requiredLearningCache, learningPlanCache, learningRecordCache)
 
 
 		req = mockReq()
@@ -537,11 +543,15 @@ describe('AudienceController', () => {
 
 			learningCatalogue.updateAudience = sinon.stub().returns(Promise.resolve(res.locals.course))
 			requiredLearningCache.deleteAllIds = sinon.stub().returns(Promise.resolve())
+			learningPlanCache.deleteAllIds = sinon.stub().returns(Promise.resolve())
+			learningRecordCache.deleteAllIds = sinon.stub().returns(Promise.resolve())
 
 			await audienceController.deleteRequiredLearning()(req, res, next)
 
 			expect(learningCatalogue.updateAudience).to.have.been.calledOnceWith('courseId', audience)
 			expect(requiredLearningCache.deleteAllIds).to.have.been.calledOnceWith()
+			expect(learningPlanCache.deleteAllIds).to.have.been.calledOnceWith()
+			expect(learningRecordCache.deleteAllIds).to.have.been.calledOnceWith()
 			expect(res.redirect).to.have.been.calledOnceWith(`/content-management/courses/courseId/audiences/audienceId/configure`)
 			expect(audience.type).to.eql(Audience.Type.OPEN)
 			expect(audience.requiredBy).to.eql(undefined)

--- a/test/unit/controllers/audience/audienceControllerTest.ts
+++ b/test/unit/controllers/audience/audienceControllerTest.ts
@@ -15,12 +15,12 @@ import {CsrsService} from '../../../../src/csrs/service/csrsService'
 import {DateTime} from '../../../../src/lib/dateTime'
 import * as moment from 'moment'
 import {Course} from '../../../../src/learning-catalogue/model/course'
-import {AudienceService} from 'lib/audienceService'
+import {AudienceService} from '../../../../src/lib/audienceService'
 import { OrganisationalUnitTypeAhead } from '../../../../src/csrs/model/organisationalUnitTypeAhead'
 import {RequiredLearningCache} from '../../../../src/csl-service/requiredLearningCache'
 import { LearningPlanCache } from '../../../../src/csl-service/learningPlanCache'
 import { LearningRecordCache } from '../../../../src/csl-service/learningRecordCache'
-
+import { LearningCacheManager } from '../../../../src/lib/learningCacheManager'
 chai.use(sinonChai)
 
 describe('AudienceController', () => {
@@ -38,6 +38,7 @@ describe('AudienceController', () => {
 	let requiredLearningCache: RequiredLearningCache
 	let learningPlanCache: LearningPlanCache
 	let learningRecordCache: LearningRecordCache
+	let learningCacheManager: LearningCacheManager
 
 	const courseId = 'course-id'
 	const audienceId = 'audience-id'
@@ -52,8 +53,8 @@ describe('AudienceController', () => {
 		requiredLearningCache = <RequiredLearningCache>{}
 		learningPlanCache = <LearningPlanCache>{}
 		learningRecordCache = <LearningRecordCache>{}
-		audienceController = new AudienceController(learningCatalogue, audienceValidator, audienceFactory, courseService, csrsService, audienceService, requiredLearningCache, learningPlanCache, learningRecordCache)
-
+		audienceController = new AudienceController(learningCatalogue, audienceValidator, audienceFactory, courseService, csrsService, audienceService)
+		learningCacheManager = new LearningCacheManager(requiredLearningCache, learningPlanCache, learningRecordCache)
 
 		req = mockReq()
 		req.session!.save = callback => {
@@ -519,7 +520,7 @@ describe('AudienceController', () => {
 
 			await audienceController.setRequiredLearning()(req, res, next)
 
-			expect(learningCatalogue.updateAudience).to.have.been.calledOnceWith(course.id, audience)
+			expect(learningCatalogue.updateAudience).to.have.been.calledOnceWith(course.id, audience, {clearLearningCache: true})
 			expect(audience.requiredBy).to.eql(requiredBy)
 			expect(audience.frequency).to.eql(frequency)
 		})
@@ -545,13 +546,11 @@ describe('AudienceController', () => {
 			requiredLearningCache.deleteAllIds = sinon.stub().returns(Promise.resolve())
 			learningPlanCache.deleteAllIds = sinon.stub().returns(Promise.resolve())
 			learningRecordCache.deleteAllIds = sinon.stub().returns(Promise.resolve())
+			learningCacheManager.clearLearningCache = sinon.stub().returns(Promise.resolve())
 
 			await audienceController.deleteRequiredLearning()(req, res, next)
 
-			expect(learningCatalogue.updateAudience).to.have.been.calledOnceWith('courseId', audience)
-			expect(requiredLearningCache.deleteAllIds).to.have.been.calledOnceWith()
-			expect(learningPlanCache.deleteAllIds).to.have.been.calledOnceWith()
-			expect(learningRecordCache.deleteAllIds).to.have.been.calledOnceWith()
+			expect(learningCatalogue.updateAudience).to.have.been.calledOnceWith('courseId', audience, {clearLearningCache: true})
 			expect(res.redirect).to.have.been.calledOnceWith(`/content-management/courses/courseId/audiences/audienceId/configure`)
 			expect(audience.type).to.eql(Audience.Type.OPEN)
 			expect(audience.requiredBy).to.eql(undefined)

--- a/test/unit/controllers/audience/audienceControllerTest.ts
+++ b/test/unit/controllers/audience/audienceControllerTest.ts
@@ -17,6 +17,7 @@ import * as moment from 'moment'
 import {Course} from '../../../../src/learning-catalogue/model/course'
 import {AudienceService} from 'lib/audienceService'
 import { OrganisationalUnitTypeAhead } from '../../../../src/csrs/model/organisationalUnitTypeAhead'
+import {RequiredLearningCache} from '../../../../src/csl-service/requiredLearningCache'
 
 chai.use(sinonChai)
 
@@ -32,6 +33,7 @@ describe('AudienceController', () => {
 	let res: Response
 	let next: NextFunction
 	let error: Error
+	let requiredLearningCache: RequiredLearningCache
 
 	const courseId = 'course-id'
 	const audienceId = 'audience-id'
@@ -43,7 +45,9 @@ describe('AudienceController', () => {
 		audienceFactory = new AudienceFactory()
 		audienceValidator = new Validator(audienceFactory)
 		audienceService = <AudienceService>{}
-		audienceController = new AudienceController(learningCatalogue, audienceValidator, audienceFactory, courseService, csrsService, audienceService)
+		requiredLearningCache = <RequiredLearningCache>{}
+		audienceController = new AudienceController(learningCatalogue, audienceValidator, audienceFactory, courseService, csrsService, audienceService, requiredLearningCache)
+
 
 		req = mockReq()
 		req.session!.save = callback => {
@@ -532,10 +536,12 @@ describe('AudienceController', () => {
 			req.params.audienceId = 'audienceId'
 
 			learningCatalogue.updateAudience = sinon.stub().returns(Promise.resolve(res.locals.course))
+			requiredLearningCache.deleteAllIds = sinon.stub().returns(Promise.resolve())
 
 			await audienceController.deleteRequiredLearning()(req, res, next)
 
 			expect(learningCatalogue.updateAudience).to.have.been.calledOnceWith('courseId', audience)
+			expect(requiredLearningCache.deleteAllIds).to.have.been.calledOnceWith()
 			expect(res.redirect).to.have.been.calledOnceWith(`/content-management/courses/courseId/audiences/audienceId/configure`)
 			expect(audience.type).to.eql(Audience.Type.OPEN)
 			expect(audience.requiredBy).to.eql(undefined)


### PR DESCRIPTION
This change:

* Creates a new class for `requiredLearning` frontend cache.
* Add 3 new functions in the cache superclass: `deleteAllIds()`, `deleteMultiple ()` and `getAllIds()`
* Update `audienceController` class to delete all `requiredLearning` cache when required learning is updated/deleted.