### PR TITLE
LC-4010 graph bug

### DIFF
--- a/src/report-service/model/course-completions/timePeriodParamsFactory.ts
+++ b/src/report-service/model/course-completions/timePeriodParamsFactory.ts
@@ -1,6 +1,6 @@
 import {TimePeriodParameters} from './timePeriodParameters'
-import {getFrontendDayJs} from '../../../utils/dateUtil'
-import {Dayjs, OpUnitType} from 'dayjs'
+import {getDayjs, getFrontendDayJs, getStartOfJs} from '../../../utils/dateUtil'
+import {Dayjs} from 'dayjs'
 import {CourseCompletionsSession} from '../../../controllers/reporting/model/courseCompletionsSession'
 
 export class TimePeriodParamsFactory {
@@ -31,10 +31,9 @@ export class TimePeriodParamsFactory {
 
 	createForCustom(startYear: string, startMonth: string, startDay: string,
 					endYear: string, endMonth: string, endDay: string,): TimePeriodParameters {
-		let start = getFrontendDayJs(`${startYear}-${startMonth}-${startDay}`)
-		let end = getFrontendDayJs(`${endYear}-${endMonth}-${endDay}`)
-		let startOf: OpUnitType = end.diff(start, 'day') <= 31 ? 'day' : 'month'
-		start = start.startOf(startOf)
+		let start = getDayjs(`${startYear}-${startMonth}-${startDay}`)
+		let end = getDayjs(`${endYear}-${endMonth}-${endDay}`)
+		start = getStartOfJs(start, end)
 		return this.createFromDates(start, end)
 	}
 

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -14,7 +14,7 @@ export function getTimezoneString(): string {
 	return `+${getFrontendDayJs().utcOffset() / 60}`
 }
 
-export function getStartOfJs(start: any, end: any) {
+export function getStartOfJs(start: any, end: any): Dayjs {
 	let startOf: OpUnitType = end.diff(start, 'day') <= 31 ? 'day' : 'month'
 	start = start.startOf(startOf)
 	if (startOf === 'day') {

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -1,4 +1,4 @@
-import {Dayjs} from 'dayjs'
+import {Dayjs, OpUnitType} from 'dayjs'
 
 var dayjs = require('dayjs')
 var utc = require('dayjs/plugin/utc')
@@ -12,6 +12,22 @@ const tz = "Europe/London"
 
 export function getTimezoneString(): string {
 	return `+${getFrontendDayJs().utcOffset() / 60}`
+}
+
+export function getStartOfJs(start: any, end: any) {
+	let startOf: OpUnitType = end.diff(start, 'day') <= 31 ? 'day' : 'month'
+	start = start.startOf(startOf)
+	if (startOf === 'day') {
+		start.tz(tz)
+	}
+	return start
+}
+
+export function getDayjs(obj?: any): Dayjs {
+	if (obj) {
+		return dayjs(obj)
+	}
+	return dayjs()
 }
 
 export function getFrontendDayJs(obj?: any): Dayjs {

--- a/test/unit/utils/dateUtilTest.ts
+++ b/test/unit/utils/dateUtilTest.ts
@@ -13,7 +13,7 @@ import {getStartOfJs} from '../../../src/utils/dateUtil'
 describe('DateUtil tests', () => {
 	describe('getStartOfJs tests', () => {
 		it('Should return the dayjs with a timezone, when the startOf is a day', () => {
-			const start = getStartOfJs(dayjs('2024-04-01'), dayjs('2025-01-01'))
+			const start = getStartOfJs(dayjs('2024-04-01').tz('Europe/London'), dayjs('2025-01-01').tz('Europe/London'))
 			expect(start.utcOffset()).to.eql(60)
 		})
 		it('Should return the dayjs without a timezone, when the startOf is a month', () => {

--- a/test/unit/utils/dateUtilTest.ts
+++ b/test/unit/utils/dateUtilTest.ts
@@ -1,0 +1,24 @@
+import {expect} from 'chai'
+
+var dayjs = require('dayjs')
+var utc = require('dayjs/plugin/utc')
+var timezone = require('dayjs/plugin/timezone')
+var advancedFormat = require("dayjs/plugin/advancedFormat");
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+dayjs.extend(advancedFormat)
+import {getStartOfJs} from '../../../src/utils/dateUtil'
+
+describe('DateUtil tests', () => {
+	describe('getStartOfJs tests', () => {
+		it('Should return the dayjs with a timezone, when the startOf is a day', () => {
+			const start = getStartOfJs(dayjs('2024-04-01'), dayjs('2025-01-01'))
+			expect(start.utcOffset()).to.eql(60)
+		})
+		it('Should return the dayjs without a timezone, when the startOf is a month', () => {
+			const start = getStartOfJs(dayjs('2024-12-01'), dayjs('2025-01-01'))
+			expect(start.utcOffset()).to.eql(-0)
+		})
+	})
+})


### PR DESCRIPTION
- When rendering the course completions dashboard for specific dates, only include timezone calculation when the diff is in days. Omit it if it's in months as this causes the start of day to shift backwards to 2300 in some cases