### PR TITLE
LC-4353 Archive learning tag bug

### DIFF
--- a/src/learning-catalogue/service/learningTagService.ts
+++ b/src/learning-catalogue/service/learningTagService.ts
@@ -74,13 +74,13 @@ export class LearningTagService {
 
 	async archive(id: number) {
 		const learningTag = await this.learningTagClient.updateState(id, 'ARCHIVE')
-		await this.learningTagCacheManager.updateAndRefresh(learningTag)
+		await this.learningTagCacheManager.clearAllAndRefresh()
 		return learningTag
 	}
 
 	async unarchive(id: number) {
 		const learningTag = await this.learningTagClient.updateState(id, 'UNARCHIVE')
-		await this.learningTagCacheManager.updateAndRefresh(learningTag)
+		await this.learningTagCacheManager.clearAllAndRefresh()
 		return learningTag
 	}
 }

--- a/src/lib/taxonomy/taxonomyItemCacheManager.ts
+++ b/src/lib/taxonomy/taxonomyItemCacheManager.ts
@@ -61,6 +61,12 @@ export class TaxonomyItemCacheManager<Object extends CachedTaxonomyItem, Formatt
 		await this.clearTypeahead()
 	}
 
+	async clearAllAndRefresh() {
+		await this.cacheableObjectCache.deleteAllIds()
+		await this.treeCache.delete()
+		await this.clearTypeahead()
+	}
+
 	async delete(ids: number[]) {
 		await Promise.all(ids.map(id => this.cacheableObjectCache.delete(id)))
 	}


### PR DESCRIPTION
- Clear all learning tags when archiving
    - This should be optimised at some point. The tag being archived/unarchived needs updating, as well as the tree entries for those tags, as opposed to all of it being deleted